### PR TITLE
Fix issues where devices can get stuck

### DIFF
--- a/Locators/NelderMeadMultilateralizer.cs
+++ b/Locators/NelderMeadMultilateralizer.cs
@@ -77,8 +77,12 @@ public class NelderMeadMultilateralizer : ILocate
                     Math.Max(_floor.Bounds[0].Z, Math.Min(_floor.Bounds[1].Z, guess.Z)),
                     scenario.Scale ?? 1.0
                 });
+                var centroid = Point3D.Centroid(nodes.Select(n => n.Node!.Location).Take(3)).ToVector();
+                var vectorToCentroid = centroid.Subtract(initialGuess.SubVector(0, 3)).Normalize(2);
+                var scaleDelta = 0.05 * initialGuess[3];
+                var initialPerturbation = Vector<double>.Build.DenseOfEnumerable(vectorToCentroid.Append(scaleDelta));
                 var solver = new NelderMeadSimplex(1e-7, 10000);
-                var result = solver.FindMinimum(obj, initialGuess);
+                var result = solver.FindMinimum(obj, initialGuess, initialPerturbation);
                 var minimizingPoint = result.MinimizingPoint.PointwiseMinimum(upperBound).PointwiseMaximum(lowerBound);
                 scenario.Location = new Point3D(minimizingPoint[0], minimizingPoint[1], minimizingPoint[2]);
                 scenario.Scale = minimizingPoint[3];


### PR DESCRIPTION
**Fix issue where devices get stuck at the upper end of the bounding box**

If the initial guess for the Nelder-Mead algorithm is close to the upper end of the bounding box Math.Net will sometimes fail to pick any test points that are inside the bounding box. It then falls back to using the initial guess as the solution, causing devices to get stuck at that location until the app is restarted. This seems to happen because the error value for those test points is all indentical (i.e. positive infinity).

This patch changes the error value calculation to add a gradient based on how far a test point is outside of the bounding box. This gives the optimization algorithm a sense of directionality. It also clamps the minimizing point to the bounding box in case we do end up with a solution that's outside of the bounding box.

This problem can be reproduced by setting at least two components of the the initial guess vector to the corresponding values of the upper bound of the bounding box:

For example, with `bounds: [[0, 0, 0], [15.26, 7.78, 2.5]]`:

```csharp
guess = new Point3D(15.26, 3.0, 2.5); // causes devices to get stuck
guess = new Point3D(15.25, 3.0, 2.5); // does not cause devices to get stuck
```

**Fix issue where devices can get stuck at X=0, Y=0 and Z=0**

This can happen because the initial test point picked by Math.Net is only 0.00025 units (for each vector component that is 0) away from the initial guess.

With this patch we're picking a (hopefully) better starting point by projecting a unit vector from the initial guess towards the centroid of the triangle that's described by the locations of the closest three nodes.

This problem can be reproduced by setting all vector components of the initial guess to 0:

```csharp
guess = new Point3D(0, 0, 0);
```

Most of the time some of the vector components of the solution will be zero temporarily - and at least some of the time the solution will converge on a value where at least one vector component is permanently zero until the app is restarted.