### PR TITLE
Fix HASS discovery, set source_type to bluetooth fixes #657

### DIFF
--- a/src/Models/AutoDiscovery.cs
+++ b/src/Models/AutoDiscovery.cs
@@ -3,47 +3,45 @@ using ESPresense.Utils;
 using Newtonsoft.Json;
 using TextExtensions;
 
-namespace ESPresense.Models
+namespace ESPresense.Models;
+
+public class AutoDiscovery(Device dev, string name, string component, string sourceType = null)
 {
-    public class AutoDiscovery
+    private bool _sent;
+
+    [JsonProperty("name")]
+    private string Name => name;
+
+    [JsonProperty("unique_id")]
+    private string UniqueId => $"espresense-companion-{dev.Id}";
+
+    [JsonProperty("state_topic")]
+    private string StateTopic => $"espresense/companion/{dev.Id}";
+
+    [JsonProperty("json_attributes_topic")]
+    private string JsonAttributesTopic => $"espresense/companion/{dev.Id}/attributes";
+
+    [JsonProperty("status_topic")]
+    private string EntityStatusTopic => "espresense/companion/status";
+
+    [JsonProperty("device")]
+    private DeviceRecord Device => new(dev.Name ?? dev.Id, "ESPresense", "Companion", "0.0.0", new[] { $"espresense-{dev.Id}" });
+
+    [JsonProperty("origin")]
+    private OriginRecord Origin => new("ESPresense Companion");
+
+    [JsonProperty("source_type")]
+    private string SourceType => sourceType;
+
+    public async Task Send(MqttCoordinator mc)
     {
-        private readonly Device _dev;
-        private readonly string _component;
+        if (_sent) return;
+        _sent = true;
 
-        public AutoDiscovery(Device dev, string component)
-        {
-            _dev = dev;
-            _component = component;
-        }
-
-        [JsonProperty("name")]
-        string Name => _dev.Name ?? _dev.Id;
-
-        [JsonProperty("unique_id")]
-        string UniqueId => $"espresense-companion-{_dev.Id}";
-
-        [JsonProperty("state_topic")]
-        string StateTopic => $"espresense/companion/{_dev.Id}";
-
-        [JsonProperty("json_attributes_topic")]
-        string JsonAttributesTopic => $"espresense/companion/{_dev.Id}/attributes";
-
-        [JsonProperty("status_topic")]
-        string EntityStatusTopic => "espresense/companion/status";
-
-        [JsonProperty("device")]
-        private DeviceRecord Device => new DeviceRecord(_dev.Name, "ESPresense", "Companion", "0.0.0", new[] { $"espresense-{_dev.Id}" });
-
-        bool _sent;
-
-        public async Task Send(MqttCoordinator mc)
-        {
-            if (_sent) return;
-            _sent = true;
-
-            await mc.EnqueueAsync($"homeassistant/{_component}/{_dev.Id.ToSnakeCase()}/config", JsonConvert.SerializeObject(this, SerializerSettings.NullIgnore), retain: true);
-        }
+        await mc.EnqueueAsync($"homeassistant/{component}/{dev.Id.ToSnakeCase()}/config", JsonConvert.SerializeObject(this, SerializerSettings.NullIgnore), true);
     }
-
-    public record DeviceRecord(string? name, string manufacturer, string model, string sw_version, string[] identifiers);
 }
+
+public record DeviceRecord(string? name, string manufacturer, string model, string sw_version, string[] identifiers);
+
+public record OriginRecord(string? name);

--- a/src/Models/Device.cs
+++ b/src/Models/Device.cs
@@ -11,7 +11,7 @@ public class Device
     {
         Id = id;
         Timeout = timeout;
-        HassAutoDiscovery.Add(new AutoDiscovery(this, "device_tracker"));
+        HassAutoDiscovery.Add(new AutoDiscovery(this, "", "device_tracker", "bluetooth"));
     }
 
     public override string ToString()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `AutoDiscovery` class to streamline initialization with new constructor parameters, improving clarity and usability.
	- Introduced an `Origin` property to encapsulate device origin information.
	- Expanded `Device` class functionality to support additional parameters for Bluetooth device discovery.

- **Bug Fixes**
	- Improved parameter handling in the `Send` method to ensure accurate message sending.

- **Refactor**
	- Simplified property references in the `AutoDiscovery` class, reducing unnecessary private fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->