### PR TITLE
If mqtt client id contains read don't write to mqtt

### DIFF
--- a/src/Models/AutoDiscovery.cs
+++ b/src/Models/AutoDiscovery.cs
@@ -33,12 +33,12 @@ public class AutoDiscovery(Device dev, string name, string component, string sou
     [JsonProperty("source_type")]
     private string SourceType => sourceType;
 
-    public async Task Send(MqttCoordinator mc)
+    public async Task Send(MqttCoordinator mqtt)
     {
         if (_sent) return;
         _sent = true;
 
-        await mc.EnqueueAsync($"homeassistant/{component}/{dev.Id.ToSnakeCase()}/config", JsonConvert.SerializeObject(this, SerializerSettings.NullIgnore), true);
+        await mqtt.EnqueueAsync($"homeassistant/{component}/{dev.Id.ToSnakeCase()}/config", JsonConvert.SerializeObject(this, SerializerSettings.NullIgnore), true);
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `ReadOnly` property in the MQTT Coordinator to manage message sending based on client state.
  
- **Bug Fixes**
	- Enhanced clarity in the code by renaming variables, improving overall readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->