### PR TITLE
Add IP address column to Nodes table

### DIFF
--- a/src/ui/src/lib/NodesTable.svelte
+++ b/src/ui/src/lib/NodesTable.svelte
@@ -15,6 +15,7 @@
 		{ key: 'telemetry.version', title: 'Version', value: (d: Node) => d.telemetry?.version ?? 'n/a', sortable: true },
 		{ key: 'cpu.name', title: 'CPU', value: (d: Node) => d.cpu?.name ?? 'n/a', sortable: true },
 		{ key: 'flavor.name', title: 'Flavor', value: (d: Node) => d.flavor?.name ?? 'n/a', sortable: true },
+		{ key: 'telemetry.ip', title: 'IP', value: (d: Node) => d.telemetry?.ip ?? 'n/a', sortable: true },
 		{ key: 'actions', title: '', renderComponent: { component: NodeActions } }
 	];
 


### PR DESCRIPTION
Minor point but helpful for me (15+ nodes) - hope OK!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "IP" column in the Nodes Table, displaying the IP address of each node.
	- The IP address defaults to 'n/a' if not available, enhancing user experience with additional information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->