### PR TITLE
Add persistent LastSeen value to device

### DIFF
--- a/src/Events/DeviceAttributesEventArgs.cs
+++ b/src/Events/DeviceAttributesEventArgs.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace ESPresense.Events
+{
+    public class DeviceAttributesEventArgs : EventArgs
+    {
+        public string DeviceId { get; set; } = string.Empty;
+        public Dictionary<string, object> Attributes { get; set; } = new Dictionary<string, object>();
+    }
+}

--- a/src/Models/Device.cs
+++ b/src/Models/Device.cs
@@ -8,6 +8,8 @@ namespace ESPresense.Models;
 
 public class Device
 {
+    private DateTime? _lastSeen;
+
     public Device(string id, string? discoveryId, TimeSpan timeout)
     {
         Id = id;
@@ -42,7 +44,19 @@ public class Device
 
     public int? Fixes => BestScenario?.Fixes;
 
-    public DateTime? LastHit => BestScenario?.LastHit ?? Nodes.Values.Max(a => a.LastHit);
+    public DateTime? LastSeen
+    {
+        get
+        {
+            var lastSeen =  BestScenario?.LastHit ?? Nodes.Values.Max(a => a.LastHit);
+            if (_lastSeen == null || lastSeen > _lastSeen) _lastSeen = lastSeen;
+            return _lastSeen;
+        }
+        set
+        {
+            _lastSeen = value;
+        }
+    }
 
     [JsonIgnore] public bool Check { get; set; }
     [JsonIgnore] public bool Track { get; set; }

--- a/src/ui/src/lib/DevicesTable.svelte
+++ b/src/ui/src/lib/DevicesTable.svelte
@@ -23,7 +23,7 @@
 		{ key: 'fixes', title: 'Fixes', value: (d) => d.fixes ?? 'n/a', sortable: true },
 		{ key: 'scale', title: 'Scale', value: (d) => d.scale?.toFixed(3) ?? 'n/a', sortable: true },
 		{ key: 'confidence', title: 'Confidence', value: (d) => d.confidence ?? 'n/a', sortable: true },
-		{ key: 'lastHit', title: 'LastHit', value: (d) => ((d.lastHit ?? '') == '' ? 'n/a' : (ago(new Date(d.lastHit)) ?? 'n/a')), sortable: true }
+		{ key: 'lastSeen', title: 'Last Seen', value: (d) => ((d.lastSeen ?? '') == '' ? 'n/a' : (ago(new Date(d.lastSeen)) ?? 'n/a')), sortable: true },
 	];
 
 	function onRowClick(e) {

--- a/src/ui/src/lib/types.ts
+++ b/src/ui/src/lib/types.ts
@@ -54,7 +54,7 @@ export interface Device {
 	scale: number;
 	fixes: number;
 	timeout: number;
-	lastHit: Date;
+	lastSeen: Date;
 }
 
 export interface MapConfig {


### PR DESCRIPTION
This will keep the Last Seen value even after reboots, a later feature can clean up items after a preset amount of time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced device attribute processing through new asynchronous messaging capabilities.
  
- **Refactor**
	- Updated device tracking to use a unified “Last Seen” timestamp for improved clarity.
	- Streamlined data payload construction for device updates, ensuring consistency across the system.
	- Adjusted user display elements to reflect the new timestamp terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->