### PR TITLE
RMSE and R

### DIFF
--- a/src/Controllers/StateController.cs
+++ b/src/Controllers/StateController.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.IO;
 using System.Text;
@@ -56,6 +56,18 @@ public class StateController : ControllerBase
         return _config.Config ?? new Config();
     }
 
+    /// <summary>
+    /// Retrieves calibration data and computes statistical measures based on active node distance measurements.
+    /// </summary>
+    /// <remarks>
+    /// Iterates through active transmitter and receiver node pairs to populate a calibration matrix with various parameters,
+    /// while collecting valid mapped and actual distance measurements. It then calculates the Pearson correlation coefficient (R)
+    /// between mapped and actual distances and the root mean square error (RMSE) to quantify deviations. The results are returned
+    /// in a Calibration object.
+    /// </remarks>
+    /// <returns>
+    /// A Calibration object containing the calibration matrix along with computed values for R and RMSE.
+    /// </returns>
     [HttpGet("api/state/calibration")]
     public Calibration GetCalibration()
     {
@@ -127,6 +139,18 @@ public class StateController : ControllerBase
         return c;
     }
 
+    /// <summary>
+    /// Opens a WebSocket connection to stream real-time state updates.
+    /// </summary>
+    /// <remarks>
+    /// This asynchronous method verifies that the request is a valid WebSocket connection and, if so, establishes the connection.
+    /// It registers event handlers to deliver updates for configuration, calibration, node state, and device changes.
+    /// Additionally, the method processes incoming commands to adjust filtering and device message subscriptions based on client input.
+    /// If the request is not a valid WebSocket request, it responds with a 400 Bad Request status.
+    /// </remarks>
+    /// <param name="showAll">
+    /// Determines whether to include all device updates (true) or only updates for tracked devices (false).
+    /// </param>
     [ApiExplorerSettings(IgnoreApi = true)]
     [Route("/ws")]
     public async Task Get([FromQuery] bool showAll = false)
@@ -264,6 +288,12 @@ public class StateController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Resets calibration settings for every node by setting TxRefRssi, RxAdjRssi, and Absorption to zero.
+    /// </summary>
+    /// <remarks>
+    /// Iterates over all nodes, updates their calibration values to zero asynchronously, and returns an HTTP 200 response on success. If an exception occurs during the process, logs the error and returns an HTTP 500 response with an error message.
+    /// </remarks>
     [HttpPost("api/state/calibration/reset")]
     public async Task<IActionResult> ResetCalibration()
     {

--- a/src/Extensions/MqttCoordinatorExtensions.cs
+++ b/src/Extensions/MqttCoordinatorExtensions.cs
@@ -5,6 +5,18 @@ namespace ESPresense.Services
 {
     public static class MqttCoordinatorExtensions
     {
+        /// <summary>
+        /// Updates the specified setting via MQTT when a change in value is detected.
+        /// </summary>
+        /// <remarks>
+        /// Compares the new and current setting values and, if they differ, logs the update and enqueues a message to update the setting on the MQTT broker. The MQTT topic is constructed using the provided identifier and setting name.
+        /// </remarks>
+        /// <param name="id">The identifier of the target node (e.g., room ID).</param>
+        /// <param name="setting">The name of the setting to update.</param>
+        /// <param name="value">The new string value for the setting; treats null or empty as an empty value.</param>
+        /// <param name="retain">Indicates whether the MQTT message should be retained.</param>
+        /// <param name="oldValue">The current string value of the setting; treats null or empty as an empty value.</param>
+        /// <returns>An asynchronous task representing the update operation.</returns>
         public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, string? value, bool retain, string? oldValue)
         {
             // Only log and send if values are different
@@ -20,6 +32,14 @@ namespace ESPresense.Services
             }
         }
 
+        /// <summary>
+        /// Updates a setting on the MQTT coordinator by converting a boolean value to its MQTT string representation ("ON" or "OFF") and delegating the update.
+        /// </summary>
+        /// <param name="id">The identifier associated with the target setting.</param>
+        /// <param name="setting">The name of the setting to update.</param>
+        /// <param name="value">The new boolean value. True is converted to "ON", false to "OFF", and null indicates no value.</param>
+        /// <param name="retain">Indicates whether the MQTT message should be retained by the broker.</param>
+        /// <param name="oldValue">The previous boolean value for comparison, where null implies an unset value.</param>
         public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, bool? value, bool retain, bool? oldValue)
         {
             // Convert to ON/OFF string format for MQTT
@@ -29,6 +49,19 @@ namespace ESPresense.Services
             await mqtt.UpdateSetting(id, setting, strValue, retain, strOldValue);
         }
 
+        /// <summary>
+        /// Asynchronously updates a setting using an integer value for MQTT transmission.
+        /// </summary>
+        /// <remarks>
+        /// Converts the provided nullable integer to its string representation before updating the setting.
+        /// For the "rx_adj_rssi" and "tx_ref_rssi" settings, a value of zero is treated as an empty string.
+        /// </remarks>
+        /// <param name="id">The identifier for the setting.</param>
+        /// <param name="setting">The name of the setting to update.</param>
+        /// <param name="value">The new integer value for the setting, or null if not specified.</param>
+        /// <param name="retain">Indicates whether the update should be retained by the MQTT broker.</param>
+        /// <param name="oldValue">The previous integer value of the setting for comparison.</param>
+        /// <returns>A Task that represents the asynchronous update operation.</returns>
         public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, int? value, bool retain, int? oldValue)
         {
             // Convert to string for comparison and mqtt
@@ -44,6 +77,19 @@ namespace ESPresense.Services
             await mqtt.UpdateSetting(id, setting, strValue, retain, strOldValue);
         }
 
+        /// <summary>
+        /// Asynchronously updates an MQTT setting using a double value.
+        /// </summary>
+        /// <remarks>
+        /// Converts the provided double value to a string formatted with two decimal places for MQTT transmission.
+        /// For the "absorption" setting, a value of 0 is converted to an empty string.
+        /// The update is dispatched only if the new value differs from the old value.
+        /// </remarks>
+        /// <param name="id">The identifier associated with the setting.</param>
+        /// <param name="setting">The name of the setting to update.</param>
+        /// <param name="value">The new double value, formatted to two decimal places if present.</param>
+        /// <param name="retain">Indicates whether the MQTT broker should retain the update.</param>
+        /// <param name="oldValue">The previous double value for change detection, formatted similarly if present.</param>
         public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, double? value, bool retain, double? oldValue)
         {
             // Convert to string with proper formatting for comparison and mqtt

--- a/src/Extensions/MqttCoordinatorExtensions.cs
+++ b/src/Extensions/MqttCoordinatorExtensions.cs
@@ -1,0 +1,62 @@
+using ESPresense.Models;
+using Serilog;
+
+namespace ESPresense.Services
+{
+    public static class MqttCoordinatorExtensions
+    {
+        public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, string? value, bool retain, string? oldValue)
+        {
+            // Only log and send if values are different
+            if (value != oldValue)
+            {
+                Log.Information("Updating {NodeId} {Setting}: {OldValue} -> {NewValue}",
+                    id,
+                    setting,
+                    string.IsNullOrEmpty(oldValue) ? "(empty)" : oldValue,
+                    string.IsNullOrEmpty(value) ? "(empty)" : value);
+
+                await mqtt.EnqueueAsync($"espresense/rooms/{id}/{setting}/set", value, retain);
+            }
+        }
+
+        public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, bool? value, bool retain, bool? oldValue)
+        {
+            // Convert to ON/OFF string format for MQTT
+            string? strValue = value.HasValue ? (value.Value ? "ON" : "OFF") : null;
+            string? strOldValue = oldValue.HasValue ? (oldValue.Value ? "ON" : "OFF") : null;
+
+            await mqtt.UpdateSetting(id, setting, strValue, retain, strOldValue);
+        }
+
+        public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, int? value, bool retain, int? oldValue)
+        {
+            // Convert to string for comparison and mqtt
+            string? strValue = value?.ToString();
+            string? strOldValue = oldValue?.ToString();
+
+            // Special handling for 0 values in certain fields
+            if ((setting == "rx_adj_rssi" || setting == "tx_ref_rssi") && value == 0)
+            {
+                strValue = "";
+            }
+
+            await mqtt.UpdateSetting(id, setting, strValue, retain, strOldValue);
+        }
+
+        public static async Task UpdateSetting(this MqttCoordinator mqtt, string id, string setting, double? value, bool retain, double? oldValue)
+        {
+            // Convert to string with proper formatting for comparison and mqtt
+            string? strValue = value.HasValue ? $"{value:0.00}" : null;
+            string? strOldValue = oldValue.HasValue ? $"{oldValue:0.00}" : null;
+
+            // Special handling for 0 values in absorption
+            if (setting == "absorption" && value == 0)
+            {
+                strValue = "";
+            }
+
+            await mqtt.UpdateSetting(id, setting, strValue, retain, strOldValue);
+        }
+    }
+}

--- a/src/Models/Calibration.cs
+++ b/src/Models/Calibration.cs
@@ -2,5 +2,7 @@
 
 public class Calibration
 {
+    public double RMSE { get; set; }
+    public double R { get; set; }
     public Dictionary<string, Dictionary<string, Dictionary<string, double>>> Matrix { get; } = new();
 }

--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -98,6 +98,12 @@ namespace ESPresense.Models
 
     public partial class ConfigOptimization
     {
+        /// <summary>
+        /// Creates a deep copy of the current ConfigOptimization instance.
+        /// </summary>
+        /// <returns>
+        /// A new ConfigOptimization instance with duplicated settings, including a separate copy of the Limits dictionary.
+        /// </returns>
         public ConfigOptimization Clone()
         {
             return new ConfigOptimization

--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -104,7 +104,7 @@ namespace ESPresense.Models
             {
                 Enabled = Enabled,
                 IntervalSecs = IntervalSecs,
-                MaxSnapshots = MaxSnapshots,
+                KeepSnapshotMins = KeepSnapshotMins,
                 Limits = new Dictionary<string, double>(Limits)
             };
         }

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -117,7 +117,7 @@ namespace ESPresense.Models
     {
         [YamlMember(Alias = "enabled")] public bool Enabled { get; set; } = false;
         [YamlMember(Alias = "interval_secs")] public int IntervalSecs { get; set; } = 60;
-        [YamlMember(Alias = "max_snapshots")] public int MaxSnapshots { get; set; } = 60;
+        [YamlMember(Alias = "keep_snapshot_mins")] public int KeepSnapshotMins { get; set; } = 5;
 
         [YamlMember(Alias = "limits")] public Dictionary<string, double> Limits { get; set;  } = new();
 

--- a/src/Models/DeviceMessage.cs
+++ b/src/Models/DeviceMessage.cs
@@ -14,6 +14,9 @@ namespace ESPresense.Models
         [JsonProperty("rssi")]
         public double Rssi { get; set; }
 
+        [JsonProperty("rxAdj")]
+        public double? RssiRxAdj { get; set; }
+
         [JsonProperty("rssiVar")]
         public double? RssiVar { get; set; }
 

--- a/src/Models/OptimizationSnapshot.cs
+++ b/src/Models/OptimizationSnapshot.cs
@@ -43,6 +43,11 @@ public class Measure
     public double Distance { get; set; }
     public double? DistVar { get; set; }
 
+    /// <summary>
+    /// Calculates and returns the unadjusted RSSI value by adding the base RSSI to the adjusted RSSI,
+    /// which defaults to 0 if not set.
+    /// </summary>
+    /// <returns>The computed unadjusted RSSI value.</returns>
     public double GetUnadjustedRssi()
     {
         return Rssi + RssiRxAdj.GetValueOrDefault(0);

--- a/src/Models/OptimizationSnapshot.cs
+++ b/src/Models/OptimizationSnapshot.cs
@@ -36,9 +36,15 @@ public class Measure
     public OptNode Tx { get; set; }
 
     public double Rssi { get; set; }
+    public double? RssiRxAdj { get; set; }
     public double? RssiVar { get; set; }
     public double RefRssi { get; set; }
 
     public double Distance { get; set; }
     public double? DistVar { get; set; }
+
+    public double GetUnadjustedRssi()
+    {
+        return Rssi + RssiRxAdj.GetValueOrDefault(0);
+    }
 }

--- a/src/Models/ProposedValues.cs
+++ b/src/Models/ProposedValues.cs
@@ -3,6 +3,7 @@ namespace ESPresense.Models;
 public class ProposedValues
 {
     public double? RxAdjRssi { get; set; }
+    public double? TxRefRssi { get; set; }
     public double? Absorption { get; set; }
     public double? Error { get; set; }
 }

--- a/src/Models/RxNode.cs
+++ b/src/Models/RxNode.cs
@@ -1,4 +1,4 @@
-﻿namespace ESPresense.Models;
+namespace ESPresense.Models;
 
 public class RxNode
 {
@@ -22,6 +22,13 @@ public class RxNode
 
     public bool Current => DateTime.UtcNow - LastHit < TimeSpan.FromSeconds(Tx?.Config?.Timeout ?? 30);
 
+    /// <summary>
+    /// Updates the node's measurement data using values from the provided device message and determines if the node has moved significantly.
+    /// </summary>
+    /// <param name="payload">A DeviceMessage containing updated metrics for signal strength, distance, and variance.</param>
+    /// <returns>
+    /// True if the absolute difference between the last recorded distance and the new distance exceeds 0.25 units; otherwise, false.
+    /// </returns>
     public bool ReadMessage(DeviceMessage payload)
     {
         Rssi = payload.Rssi;

--- a/src/Models/RxNode.cs
+++ b/src/Models/RxNode.cs
@@ -9,6 +9,7 @@ public class RxNode
     public double? DistVar { get; set; }
 
     public double Rssi { get; set; }
+    public double? RssiRxAdj { get; set; }
     public double? RssiVar { get; set; }
     public double RefRssi { get; set; }
 
@@ -24,6 +25,7 @@ public class RxNode
     public bool ReadMessage(DeviceMessage payload)
     {
         Rssi = payload.Rssi;
+        RssiRxAdj = payload.RssiRxAdj;
         RssiVar = payload.RssiVar;
         RefRssi = payload.RefRssi;
         var moved = Math.Abs(LastDistance - payload.Distance) > 0.25;

--- a/src/Models/State.cs
+++ b/src/Models/State.cs
@@ -96,6 +96,7 @@ public class State
                         Rssi = meas.Rssi,
                         RssiVar = meas.RssiVar,
                         RefRssi = meas.RefRssi,
+                        RssiRxAdj = meas.RssiRxAdj,
                         Tx = tx,
                         Rx = rx,
                     });

--- a/src/Models/State.cs
+++ b/src/Models/State.cs
@@ -75,6 +75,15 @@ public class State
     public List<OptimizationSnapshot> OptimizationSnaphots { get; } = new();
     public IWeighting? Weighting { get; set; }
 
+    /// <summary>
+    /// Creates an optimization snapshot from current node measurements and purges expired snapshots.
+    /// </summary>
+    /// <remarks>
+    /// Iterates through all nodes and their receiver measurements, recording only those marked as current into a new snapshot
+    /// timestamped with the current UTC time. It then removes any snapshots older than the configured expiration threshold
+    /// (defaulting to 5 minutes) before adding the new snapshot to the collection.
+    /// </remarks>
+    /// <returns>The newly created optimization snapshot containing active measurements.</returns>
     public OptimizationSnapshot TakeOptimizationSnapshot()
     {
         Dictionary<string, OptNode> nodes = new();
@@ -96,7 +105,6 @@ public class State
                         Rssi = meas.Rssi,
                         RssiVar = meas.RssiVar,
                         RefRssi = meas.RefRssi,
-                        RssiRxAdj = meas.RssiRxAdj,
                         Tx = tx,
                         Rx = rx,
                     });

--- a/src/Optimizers/JointRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/JointRxAdjAbsorptionOptimizer.cs
@@ -54,7 +54,7 @@ public class JointRxAdjAbsorptionOptimizer : IOptimizer
 
                         error += 0.25 * ( Math.Abs(x[0]) + Math.Pow(x[1] - absorptionMiddle, 2));
 
-                        Log.Debug("Optimized {0,-20}     : RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3}", g.Key.Id, x[0], x[1], error);
+                        Log.Debug("Optimized {0,-20}     : RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3:0.0}", g.Key.Id, x[0], x[1], error);
                         return error;
                     });
 
@@ -67,7 +67,7 @@ public class JointRxAdjAbsorptionOptimizer : IOptimizer
                 var rxAdjRssi = Math.Clamp(result.MinimizingPoint[0], optimization.RxAdjRssiMin, optimization.RxAdjRssiMax);
                 var absorption = Math.Clamp(result.MinimizingPoint[1], optimization.AbsorptionMin, optimization.AbsorptionMax);
 
-                Log.Information("Optimized {0,-20}     : RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3}",
+                Log.Information("Optimized {0,-20}     : RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3:0.0}",
                     g.Key.Id, rxAdjRssi, absorption, result.FunctionInfoAtMinimum.Value);
 
                 or.Nodes.Add(g.Key.Id, new ProposedValues

--- a/src/Optimizers/JointRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/JointRxAdjAbsorptionOptimizer.cs
@@ -16,6 +16,16 @@ public class JointRxAdjAbsorptionOptimizer : IOptimizer
 
     public string Name => "Joint RxAdj & Absorption";
 
+    /// <summary>
+    /// Optimizes radio receiver adjustment (RxAdjRssi) and absorption parameters for each receiver group in the provided snapshot.
+    /// </summary>
+    /// <param name="os">The snapshot containing groups of receiver nodes to process for optimization.</param>
+    /// <returns>
+    /// An <see cref="OptimizationResults"/> object aggregating the optimized values for each receiver group.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the optimization configuration is not available in the state.
+    /// </exception>
     public OptimizationResults Optimize(OptimizationSnapshot os)
     {
         OptimizationResults or = new();

--- a/src/Optimizers/TwoStageRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/TwoStageRxAdjAbsorptionOptimizer.cs
@@ -92,7 +92,7 @@ public class TwoStageRxAdjAbsorptionOptimizer : IOptimizer
                 var resultAbs = solverAbs.FindMinimum(objAbs, initialGuessAbs);
                 var absorption = Math.Clamp(resultAbs.MinimizingPoint[0], absorptionMin, absorptionMax); // Fixed index from [1] to [0]
 
-                Log.Information("Optimized {0,-20}: RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3}",
+                Log.Information("Optimized {0,-20}: RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3:0.0}",
                     g.Key.Id, rxAdjRssi, absorption, resultAbs.FunctionInfoAtMinimum.Value);
 
                 or.Nodes.Add(g.Key.Id, new ProposedValues

--- a/src/Optimizers/TwoStageRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/TwoStageRxAdjAbsorptionOptimizer.cs
@@ -16,6 +16,19 @@ public class TwoStageRxAdjAbsorptionOptimizer : IOptimizer
 
     public string Name => "Two-Stage RxAdj & Absorption";
 
+    /// <summary>
+    /// Optimizes radio signal parameters using a two-stage process.
+    /// </summary>
+    /// <remarks>
+    /// The method retrieves configuration settings to establish bounds for the Rx RSSI adjustment and absorption parameters. It processes groups of nodes from the provided snapshot (ignoring groups with fewer than three nodes). In stage 1, it calibrates the Rx RSSI adjustment using nearby nodes (or all nodes if no close ones are found) with a fixed absorption value. In stage 2, it refines the absorption parameter based on all nodes with the previously optimized Rx RSSI adjustment. Optimization is performed using the Nelder–Mead simplex algorithm, and results are clamped within the specified bounds. Exceptions during group processing are caught and logged, while an InvalidOperationException is thrown if the required optimization configuration is missing.
+    /// </remarks>
+    /// <param name="os">A snapshot representing the current node groups to optimize.</param>
+    /// <returns>
+    /// An OptimizationResults object mapping node identifiers to their proposed values, including the optimized Rx RSSI adjustment, absorption, and error measurement.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the optimization configuration is not found in the current state.
+    /// </exception>
     public OptimizationResults Optimize(OptimizationSnapshot os)
     {
         OptimizationResults or = new();

--- a/src/Optimizers/WeightedJointRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/WeightedJointRxAdjAbsorptionOptimizer.cs
@@ -16,6 +16,19 @@ public class WeightedJointRxAdjAbsorptionOptimizer : IOptimizer
 
     public string Name => "Weighted Joint RxAdj & Absorption";
 
+    /// <summary>
+    /// Optimizes RSSI adjustment and absorption parameters for each receiver group based on measurement data.
+    /// </summary>
+    /// <param name="os">An optimization snapshot containing groups of measurements organized by receiver.</param>
+    /// <returns>
+    /// An <see cref="OptimizationResults"/> instance mapping receiver node IDs to their proposed RxAdj, absorption, and error values.
+    /// </returns>
+    /// <remarks>
+    /// The method derives configuration bounds from the state (or defaults if undefined) and logs these bounds. For each receiver group with at least three measurements,
+    /// it computes distances between transmitter and receiver positions and defines an objective function that evaluates a weighted squared error between observed and
+    /// predicted distances. Optimization is then performed using the Nelder-Mead simplex method, and the resulting parameters are clamped within the specified bounds.
+    /// Any exceptions during a group’s optimization are caught and logged.
+    /// </remarks>
     public OptimizationResults Optimize(OptimizationSnapshot os)
     {
         OptimizationResults or = new();

--- a/src/Optimizers/WeightedJointRxAdjAbsorptionOptimizer.cs
+++ b/src/Optimizers/WeightedJointRxAdjAbsorptionOptimizer.cs
@@ -77,7 +77,7 @@ public class WeightedJointRxAdjAbsorptionOptimizer : IOptimizer
                 var rxAdjRssi = Math.Clamp(result.MinimizingPoint[0], rxAdjMin, rxAdjMax);
                 var absorption = Math.Clamp(result.MinimizingPoint[1], absorptionMin, absorptionMax);
 
-                Log.Information("Optimized {0,-20}: RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3}",
+                Log.Information("Optimized {0,-20}: RxAdj: {1:0.00} dBm, Absorption: {2:0.00}, Error: {3:0.0}",
                     g.Key.Id, rxAdjRssi, absorption, result.FunctionInfoAtMinimum.Value);
 
                 or.Nodes.Add(g.Key.Id, new ProposedValues

--- a/src/Services/NodeSettingsStore.cs
+++ b/src/Services/NodeSettingsStore.cs
@@ -32,49 +32,60 @@ namespace ESPresense.Services
             var old = Get(id);
 
             if (ds.Name != null && ds.Name != old.Name)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/name/set", ds.Name, retain);
+                await mqtt.UpdateSetting(id, "name", ds.Name, retain, old.Name);
 
             // Updating settings
             if (ds.Updating.AutoUpdate != null && ds.Updating.AutoUpdate != old.Updating.AutoUpdate)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/auto_update/set", ds.Updating.AutoUpdate == true ? "ON" : "OFF", retain);
+                await mqtt.UpdateSetting(id, "auto_update", ds.Updating.AutoUpdate, retain, old.Updating.AutoUpdate);
+
             if (ds.Updating.Prerelease != null && ds.Updating.Prerelease != old.Updating.Prerelease)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/prerelease/set", ds.Updating.Prerelease == true ? "ON" : "OFF", retain);
+                await mqtt.UpdateSetting(id, "prerelease", ds.Updating.Prerelease, retain, old.Updating.Prerelease);
 
             // Scanning settings
             if (ds.Scanning.ForgetAfterMs != null && ds.Scanning.ForgetAfterMs != old.Scanning.ForgetAfterMs)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/forget_after_ms/set", $"{ds.Scanning.ForgetAfterMs}", retain);
+                await mqtt.UpdateSetting(id, "forget_after_ms", ds.Scanning.ForgetAfterMs, retain, old.Scanning.ForgetAfterMs);
 
             // Counting settings
             if (ds.Counting.IdPrefixes != null && ds.Counting.IdPrefixes != old.Counting.IdPrefixes)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/count_ids/set", $"{ds.Counting.IdPrefixes}", retain);
+                await mqtt.UpdateSetting(id, "count_ids", ds.Counting.IdPrefixes, retain, old.Counting.IdPrefixes);
+
             if (ds.Counting.MinDistance != null && ds.Counting.MinDistance != old.Counting.MinDistance)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/count_min_dist/set", $"{ds.Counting.MinDistance:0.00}", retain);
+                await mqtt.UpdateSetting(id, "count_min_dist", ds.Counting.MinDistance, retain, old.Counting.MinDistance);
+
             if (ds.Counting.MaxDistance != null && ds.Counting.MaxDistance != old.Counting.MaxDistance)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/count_max_dist/set", $"{ds.Counting.MaxDistance:0.00}", retain);
+                await mqtt.UpdateSetting(id, "count_max_dist", ds.Counting.MaxDistance, retain, old.Counting.MaxDistance);
+
             if (ds.Counting.MinMs != null && ds.Counting.MinMs != old.Counting.MinMs)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/count_ms/set", $"{ds.Counting.MinMs}", retain);
+                await mqtt.UpdateSetting(id, "count_ms", ds.Counting.MinMs, retain, old.Counting.MinMs);
 
             // Filtering settings
             if (ds.Filtering.IncludeIds != null && ds.Filtering.IncludeIds != old.Filtering.IncludeIds)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/include/set", $"{ds.Filtering.IncludeIds}", retain);
+                await mqtt.UpdateSetting(id, "include", ds.Filtering.IncludeIds, retain, old.Filtering.IncludeIds);
+
             if (ds.Filtering.ExcludeIds != null && ds.Filtering.ExcludeIds != old.Filtering.ExcludeIds)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/exclude/set", $"{ds.Filtering.ExcludeIds}", retain);
+                await mqtt.UpdateSetting(id, "exclude", ds.Filtering.ExcludeIds, retain, old.Filtering.ExcludeIds);
+
             if (ds.Filtering.MaxDistance != null && ds.Filtering.MaxDistance != old.Filtering.MaxDistance)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/max_distance/set", $"{ds.Filtering.MaxDistance:0.00}", retain);
+                await mqtt.UpdateSetting(id, "max_distance", ds.Filtering.MaxDistance, retain, old.Filtering.MaxDistance);
+
             if (ds.Filtering.SkipDistance != null && ds.Filtering.SkipDistance != old.Filtering.SkipDistance)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/skip_distance/set", $"{ds.Filtering.SkipDistance:0.00}", retain);
+                await mqtt.UpdateSetting(id, "skip_distance", ds.Filtering.SkipDistance, retain, old.Filtering.SkipDistance);
+
             if (ds.Filtering.SkipMs != null && ds.Filtering.SkipMs != old.Filtering.SkipMs)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/skip_ms/set", $"{ds.Filtering.SkipMs}", retain);
+                await mqtt.UpdateSetting(id, "skip_ms", ds.Filtering.SkipMs, retain, old.Filtering.SkipMs);
 
             // Calibration settings
             if (ds.Calibration.Absorption != null && ds.Calibration.Absorption != old.Calibration.Absorption)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/absorption/set", $"{ds.Calibration.Absorption:0.00}", retain);
+                await mqtt.UpdateSetting(id, "absorption", ds.Calibration.Absorption, retain, old.Calibration.Absorption);
+
             if (ds.Calibration.RxAdjRssi != null && ds.Calibration.RxAdjRssi != old.Calibration.RxAdjRssi)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/rx_adj_rssi/set", $"{ds.Calibration.RxAdjRssi}", retain);
+                await mqtt.UpdateSetting(id, "rx_adj_rssi", ds.Calibration.RxAdjRssi, retain, old.Calibration.RxAdjRssi);
+
             if (ds.Calibration.TxRefRssi != null && ds.Calibration.TxRefRssi != old.Calibration.TxRefRssi)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/tx_ref_rssi/set", $"{ds.Calibration.TxRefRssi}", retain);
+                await mqtt.UpdateSetting(id, "tx_ref_rssi", ds.Calibration.TxRefRssi, retain, old.Calibration.TxRefRssi);
+
             if (ds.Calibration.RxRefRssi != null && ds.Calibration.RxRefRssi != old.Calibration.RxRefRssi)
-                await mqtt.EnqueueAsync($"espresense/rooms/{id}/ref_rssi/set", $"{ds.Calibration.RxRefRssi}", retain);
+                await mqtt.UpdateSetting(id, "ref_rssi", ds.Calibration.RxRefRssi, retain, old.Calibration.RxRefRssi);
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -28,6 +28,7 @@ away_timeout: 120
 optimization:
   enabled: true
   interval_secs: 3600
+  keep_snapshot_mins: 5   # How long to keep optimization snapshots (default: 5 minutes)
   limits:
     absorption_min: 2.5
     absorption_max: 3.5

--- a/src/ui/src/lib/NodeCalibrationMatrix.svelte
+++ b/src/ui/src/lib/NodeCalibrationMatrix.svelte
@@ -73,7 +73,7 @@
 	const modalStore = getModalStore();
 
 	async function resetCalibration() {
-		const confirmed = await new Promise(resolve => {
+		const confirmed = await new Promise((resolve) => {
 			modalStore.trigger({
 				type: 'confirm',
 				title: 'Reset Calibration',
@@ -133,6 +133,10 @@
 					<RadioItem bind:group={data_point} name="justify" value={5}>Variance (m)</RadioItem>
 				</RadioGroup>
 				<button class="btn variant-filled-warning" on:click={resetCalibration}> Reset Calibration </button>
+			</div>
+			<div class="flex gap-8 items-center m-4 mt-0">
+				<span class="font-semibold">RMSE:</span> <span>{$calibration?.rmse?.toFixed(3) ?? 'n/a'}</span>
+				<span class="font-semibold">R:</span> <span>{$calibration?.r?.toFixed(3) ?? 'n/a'}</span>
 			</div>
 		</header>
 		<section class="p-4 pt-0">

--- a/src/ui/src/lib/types.ts
+++ b/src/ui/src/lib/types.ts
@@ -212,6 +212,15 @@ export interface CalibrationResponse {
 	r?: number;
 }
 
+/**
+ * Determines if the provided object is a Node.
+ *
+ * This type guard checks if the object has a defined telemetry property,
+ * confirming it as a Node rather than a Device or null.
+ *
+ * @param d - Object to check (can be a Device, Node, or null).
+ * @returns True if the object is a Node; otherwise, false.
+ */
 export function isNode(d: Device | Node | null): d is Node {
 	return (d as Node)?.telemetry !== undefined;
 }

--- a/src/ui/src/lib/types.ts
+++ b/src/ui/src/lib/types.ts
@@ -208,6 +208,8 @@ export interface NodeCalibrationMatrix {
 
 export interface CalibrationResponse {
 	matrix: NodeCalibrationMatrix;
+	rmse?: number;
+	r?: number;
 }
 
 export function isNode(d: Device | Node | null): d is Node {
@@ -217,11 +219,11 @@ export function isNode(d: Device | Node | null): d is Node {
 
 export interface DeviceHistory {
 	id: string;
-	when: string; // ISO date string
+	when: string;
 	location: { x: number; y: number; z: number };
 	confidence?: number;
 	fixes?: number;
 	scale?: number;
-	room?: string; // Room ID
-	floor?: string; // Floor ID
+	room?: string;
+	floor?: string;
 }


### PR DESCRIPTION
Config change: keep_snapshot_mins added to replace max_snapshots 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The calibration process now provides enhanced statistical metrics, including RMSE and correlation (R), which are displayed in the calibration interface.
  - Device signal details have been improved, offering additional adjustments for refined signal quality insights.
  - Optimization snapshots now expire based on a configurable retention period for better data management.
  - New configuration option added to control the retention duration of optimization snapshots.
  - Added optional properties for RMSE and R in calibration response structures.

- **Bug Fixes**
  - Adjusted the promise resolution syntax in the calibration reset function for consistency.

- **Documentation**
  - Updated configuration example to include the new snapshot retention setting.
  - Added XML documentation for various methods to enhance clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->