### PR TITLE
Remove GPS coordinate reporting via MQTT and improve away reporting

### DIFF
--- a/src/Services/DeviceTracker.cs
+++ b/src/Services/DeviceTracker.cs
@@ -49,7 +49,7 @@ public class DeviceTracker(State state, MqttCoordinator mqtt, TelemetryService t
 
             var device = state.Devices.GetOrAdd(deviceId, id =>
             {
-                var d = new Device(id, arg.AutoDiscover.DiscoveryId, TimeSpan.FromSeconds(state.Config?.Timeout ?? 30)) { Name = arg.AutoDiscover.Message.Name, Track = true, Check = true, LastCalculated = DateTime.UtcNow };
+                var d = new Device(id, arg.AutoDiscover.DiscoveryId, TimeSpan.FromSeconds(state.Config?.Timeout ?? 30), TimeSpan.FromSeconds(state.Config?.AwayTimeout ?? 120)) { Name = arg.AutoDiscover.Message.Name, Track = true, Check = true, LastCalculated = DateTime.UtcNow };
                 foreach (var scenario in state.GetScenarios(d)) d.Scenarios.Add(scenario);
                 Log.Information("[+] Track: {Device} (disc)", d);
                 return d;
@@ -87,7 +87,7 @@ public class DeviceTracker(State state, MqttCoordinator mqtt, TelemetryService t
                     tele.IncrementMessages();
                     var device = state.Devices.GetOrAdd(arg.DeviceId, id =>
                     {
-                        var d = new Device(id, null, TimeSpan.FromSeconds(state.Config?.Timeout ?? 30)) { Check = true };
+                        var d = new Device(id, null, TimeSpan.FromSeconds(state.Config?.Timeout ?? 30), TimeSpan.FromSeconds(state.Config?.AwayTimeout ?? 120)) { Check = true };
                         foreach (var scenario in state.GetScenarios(d)) d.Scenarios.Add(scenario);
                         return d;
                     });


### PR DESCRIPTION
Fixes #1143 

Don't report GPS coordinates via MQTT because the coordinates will override reported device state in HA MQTT device tracker. Unfortunately HA MQTT device tracker doesn't seem to follow location_name attribute for device state. Report device state with separate MQTT topic like before.

Explicitly report device state as not_home in MultiScenarioLocator if device is considered away. Otherwise devices will report latest location as state even though devices are actually away. Use configuration parameter away_timeout to determine if device is away or not.

Change is tested locally in my own Home Assistant environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Devices now support an "away timeout" setting to determine when they are considered away.
	- Devices can now be explicitly marked as "not_home" if no movement is detected and they have exceeded the away timeout.
- **Refactor**
	- Device state publishing logic has been reorganized for improved clarity and accuracy.
	- Device attribute payloads have been simplified to remove GPS-specific fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->