### PR TITLE
Fix Nelder-Mead locator naming typo

### DIFF
--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -36,7 +36,7 @@ namespace ESPresense.Models
             return new ConfigLocators
             {
                 NadarayaWatson = NadarayaWatson.Clone(),
-                NealderMead = NealderMead.Clone(),
+                NelderMead = NelderMead.Clone(),
                 NearestNode = NearestNode.Clone()
             };
         }
@@ -56,11 +56,11 @@ namespace ESPresense.Models
         }
     }
 
-    public partial class NealderMeadConfig
+    public partial class NelderMeadConfig
     {
-        public NealderMeadConfig Clone()
+        public NelderMeadConfig Clone()
         {
-            return new NealderMeadConfig
+            return new NelderMeadConfig
             {
                 Enabled = Enabled,
                 Floors = Floors?.ToArray(),

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -52,8 +52,8 @@ namespace ESPresense.Models
         [YamlMember(Alias = "nadaraya_watson")]
         public NadarayaWatsonConfig NadarayaWatson { get; set; } = new();
 
-        [YamlMember(Alias = "nealder_mead")]
-        public NealderMeadConfig NealderMead { get; set; } = new();
+        [YamlMember(Alias = "nelder_mead")]
+        public NelderMeadConfig NelderMead { get; set; } = new();
 
         [YamlMember(Alias = "nearest_node")]
         public NearestNodeConfig NearestNode { get; set; } = new();
@@ -74,7 +74,7 @@ namespace ESPresense.Models
         public string Kernel { get; set; } = "gaussian";
     }
 
-    public partial class NealderMeadConfig
+    public partial class NelderMeadConfig
     {
         [YamlMember(Alias = "enabled")]
         public bool Enabled { get; set; }

--- a/src/Models/State.cs
+++ b/src/Models/State.cs
@@ -51,7 +51,7 @@ public class State
             NamesToTrack = namesToTrack;
             ConfigDeviceByName = configDeviceByName;
 
-            var w = c?.Locators?.NealderMead?.Weighting;
+            var w = c?.Locators?.NelderMead?.Weighting;
             Weighting = w?.Algorithm switch
             {
                 "equal" => new EqualWeighting(),
@@ -140,14 +140,14 @@ public class State
 
     public IEnumerable<Scenario> GetScenarios(Device device)
     {
-        var nealderMead = Config?.Locators?.NealderMead;
+        var nelderMead = Config?.Locators?.NelderMead;
         var nadarayaWatson = Config?.Locators?.NadarayaWatson;
         var nearestNode = Config?.Locators?.NearestNode;
 
-        if ((nealderMead?.Enabled ?? false) || (nadarayaWatson?.Enabled ?? false) || (nearestNode?.Enabled ?? false))
+        if ((nelderMead?.Enabled ?? false) || (nadarayaWatson?.Enabled ?? false) || (nearestNode?.Enabled ?? false))
         {
-            if (nealderMead?.Enabled ?? false)
-                foreach (var floor in GetFloorsByIds(nealderMead?.Floors))
+            if (nelderMead?.Enabled ?? false)
+                foreach (var floor in GetFloorsByIds(nelderMead?.Floors))
                     yield return new Scenario(Config, new NelderMeadMultilateralizer(device, floor, this), floor.Name);
 
             if (nadarayaWatson?.Enabled ?? false)

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -54,7 +54,7 @@ locators:
     bandwidth: 0.5
     kernel: gaussian
 
-  nealder_mead:
+  nelder_mead:
     enabled: false
     floors: ["first", "second"]
     weighting:

--- a/tests/ConfigTests.cs
+++ b/tests/ConfigTests.cs
@@ -17,7 +17,7 @@ public class ConfigTests
             floors: [""floor1"", ""floor2""]
             bandwidth: 0.5
             kernel: ""gaussian""
-          nealder_mead:
+          nelder_mead:
             enabled: false
             floors: [""floor3""]
           nearest_node:
@@ -37,9 +37,9 @@ public class ConfigTests
         Assert.That(nadarayaWatson.Bandwidth, Is.EqualTo(0.5));
         Assert.That(nadarayaWatson.Kernel, Is.EqualTo("gaussian"));
 
-        var nealderMead = config.Locators.NealderMead;
-        Assert.False(nealderMead.Enabled);
-        Assert.That(nealderMead.Floors, Is.EqualTo(new[] { "floor3" }));
+        var nelderMead = config.Locators.NelderMead;
+        Assert.False(nelderMead.Enabled);
+        Assert.That(nelderMead.Floors, Is.EqualTo(new[] { "floor3" }));
 
         var nearestNode = config.Locators.NearestNode;
         Assert.True(nearestNode.Enabled);


### PR DESCRIPTION
## Summary
- fix typo in config models and config example
- update state logic and tests

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_683f770a545883248df00035d3c8bc55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of "NealderMead" to "NelderMead" throughout the application, including configuration files, user-facing property names, and documentation.
- **Tests**
	- Updated test cases to use the corrected "NelderMead" naming in configuration and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->