### PR TITLE
Fix Svelte typo

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,3 +1,3 @@
-This is a C# project and src/ui is the Svelete 5 UI for it
+This is a C# project and src/ui is the Svelte 5 UI for it
 Test via `dotnet watch --project src`
 Don't fix warnings and typescript issues unless it relates to your task


### PR DESCRIPTION
## Summary
- fix typographical error referencing the UI framework

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f860c0e888324bbed7df3c43cd980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a typo in a comment to display "Svelte 5 UI" instead of "Svelete 5 UI".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->