### PR TITLE
Add unit tests for TimeSpan extension parser

### DIFF
--- a/tests/TimeSpanExtensionsTests.cs
+++ b/tests/TimeSpanExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using ESPresense.Extensions;
+using NUnit.Framework;
 
 namespace ESPresense.Companion.Tests;
 

--- a/tests/TimeSpanExtensionsTests.cs
+++ b/tests/TimeSpanExtensionsTests.cs
@@ -1,0 +1,31 @@
+using System;
+using ESPresense.Extensions;
+
+namespace ESPresense.Companion.Tests;
+
+public class TimeSpanExtensionsTests
+{
+    [Test]
+    public void TryParseDurationString_ValidCompound_ReturnsExpectedTimeSpan()
+    {
+        var result = "1h30m".TryParseDurationString(out var ts);
+        Assert.IsTrue(result);
+        Assert.That(ts, Is.EqualTo(TimeSpan.FromMinutes(90)));
+    }
+
+    [Test]
+    public void TryParseDurationString_ValidMixedUnits_ReturnsExpectedTimeSpan()
+    {
+        var result = "1d2h3m4s".TryParseDurationString(out var ts);
+        Assert.IsTrue(result);
+        Assert.That(ts, Is.EqualTo(new TimeSpan(1, 2, 3, 4)));
+    }
+
+    [Test]
+    public void TryParseDurationString_InvalidString_ReturnsFalse()
+    {
+        var result = "1h30x".TryParseDurationString(out var ts);
+        Assert.IsFalse(result);
+        Assert.That(ts, Is.EqualTo(default(TimeSpan)));
+    }
+}


### PR DESCRIPTION
## Summary
- add `TimeSpanExtensionsTests` covering duration string parser

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_683f85ffa0ac8324bcee5611e8fbe3ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new unit tests to verify duration string parsing, including scenarios for valid compound durations, mixed-unit durations, and invalid strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->