### PR TITLE
Add GPS reporting toggle

### DIFF
--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -149,7 +149,8 @@ namespace ESPresense.Models
             {
                 Latitude = Latitude,
                 Longitude = Longitude,
-                Elevation = Elevation
+                Elevation = Elevation,
+                Report = Report
             };
         }
     }

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -164,6 +164,8 @@ namespace ESPresense.Models
         public double? Elevation { get; set; }
         [YamlMember(Alias = "rotation")]
         public double? Rotation { get; set; } // Degrees clockwise from North
+        [YamlMember(Alias = "report")]
+        public bool Report { get; set; } = false;
     }
 
     public partial class ConfigMqtt

--- a/src/Services/MultiScenarioLocator.cs
+++ b/src/Services/MultiScenarioLocator.cs
@@ -124,15 +124,17 @@ public class MultiScenarioLocator(DeviceTracker dl,
 
                 var gps      = state?.Config?.Gps;
                 var location = device.Location ?? new Point3D();
-                // Use extension method syntax again, now that the namespace is imported
-                var (lat, lon) = gps.Add(location.X, location.Y);
+
+                // Only include GPS coordinates if reporting is enabled
+                var (lat, lon) = gps?.Report == true ? gps.Add(location.X, location.Y) : (null, null);
+                var elevation = gps?.Report == true ? location.Z + gps?.Elevation : null;
 
                 var payload = JsonConvert.SerializeObject(new
                 {
                     source_type   = "espresense",
                     latitude      = lat,
                     longitude     = lon,
-                    elevation     = location.Z + gps?.Elevation,
+                    elevation     = elevation,
                     x             = location.X,
                     y             = location.Y,
                     z             = location.Z,

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -12,6 +12,7 @@ gps:
   longitude: -77.036560
   elevation: 146
   rotation: 10 # Rotation in degrees from north (0 degrees)
+  report: false # Include GPS latitude/longitude when reporting to Home Assistant
 
 map:
   flip_x: false        # Set to true to flip X coordinates (default: false)

--- a/src/ui/src/lib/types.ts
+++ b/src/ui/src/lib/types.ts
@@ -66,10 +66,11 @@ export interface MapConfig {
 }
 
 export interface ConfigGps {
-	latitude?: number | null;
-	longitude?: number | null;
-	elevation?: number | null;
-	rotation?: number | null; // Degrees clockwise from North
+        latitude?: number | null;
+        longitude?: number | null;
+        elevation?: number | null;
+        rotation?: number | null; // Degrees clockwise from North
+        report?: boolean; // Include GPS coordinates when reporting to Home Assistant
 }
 
 


### PR DESCRIPTION
## Summary
- add `report` flag to `ConfigGps`
- skip sending latitude/longitude unless enabled
- update example config and TS types
- fixes https://github.com/ESPresense/ESPresense-companion/issues/1143
------
https://chatgpt.com/codex/tasks/task_e_683f8a7675648324bdb58d93f684c2fc