### PR TITLE
Fix not_home update and add regression test

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ESPresense.Companion.Tests")]

--- a/src/Services/MqttCoordinator.cs
+++ b/src/Services/MqttCoordinator.cs
@@ -258,7 +258,7 @@ public class MqttCoordinator
 
     private bool ReadOnly => _mqttClient?.Options.ClientOptions.ClientId.ToLower().Contains("read") ?? false;
 
-    public async Task EnqueueAsync(string topic, string? payload, bool retain = false)
+    public virtual async Task EnqueueAsync(string topic, string? payload, bool retain = false)
     {
         var client = await GetClient();
 

--- a/src/Services/MultiScenarioLocator.cs
+++ b/src/Services/MultiScenarioLocator.cs
@@ -117,6 +117,12 @@ public class MultiScenarioLocator(DeviceTracker dl,
                     device.ReportedState = newState;
                 }
             }
+            else if (device.ReportedState != "not_home")
+            {
+                moved += 1;
+                await mqtt.EnqueueAsync($"espresense/companion/{device.Id}", "not_home");
+                device.ReportedState = "not_home";
+            }
 
             if (moved > 0 && bestScenario != null)
             {

--- a/src/Services/MultiScenarioLocator.cs
+++ b/src/Services/MultiScenarioLocator.cs
@@ -28,10 +28,8 @@ public class MultiScenarioLocator(DeviceTracker dl,
     private const double NewDataWeight   = 0.3;
     private const double MotionSigma     = 2.0;  // metres, for Gaussian weight
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    internal async Task ProcessDevice(Device device)
     {
-        await foreach (var device in dl.GetConsumingEnumerable(stoppingToken))
-        {
             // -----------------------------------------------------------------
             // 1. Refresh all scenarios -------------------------------------------------
             // -----------------------------------------------------------------
@@ -174,6 +172,13 @@ public class MultiScenarioLocator(DeviceTracker dl,
                     }
                 }
             }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var device in dl.GetConsumingEnumerable(stoppingToken))
+        {
+            await ProcessDevice(device);
         }
     }
 }

--- a/tests/ESPresense.Companion.Tests.csproj
+++ b/tests/ESPresense.Companion.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MultiScenarioLocatorTests.cs
+++ b/tests/MultiScenarioLocatorTests.cs
@@ -1,5 +1,11 @@
 using ESPresense.Models;
 using ESPresense.Locators;
+using ESPresense.Services;
+using ESPresense.Utils;
+using ESPresense.Controllers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SQLite;
 
 namespace ESPresense.Companion.Tests;
 
@@ -11,8 +17,27 @@ public class MultiScenarioLocatorTests
     }
 
     [Test]
-    public void NotHomeStateWhenAllScenariosExpire()
+    public async Task NotHomeStateWhenAllScenariosExpire()
     {
+        // Arrange minimal environment
+        var workDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg");
+        Directory.CreateDirectory(workDir);
+
+        var configLoader = new ConfigLoader(workDir);
+        var supervisor = new SupervisorConfigLoader(NullLogger<SupervisorConfigLoader>.Instance);
+
+        var mqttMock = new Mock<MqttCoordinator>(configLoader,
+            NullLogger<MqttCoordinator>.Instance,
+            new MqttNetLogger(),
+            supervisor);
+
+        var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object));
+        var tele = new TelemetryService(mqttMock.Object);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher());
+        var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
+
+        var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history);
+
         var device = new Device("id", null, TimeSpan.FromSeconds(1))
         {
             ReportedState = "kitchen"
@@ -24,28 +49,16 @@ public class MultiScenarioLocatorTests
         };
         device.Scenarios.Add(scenario);
 
-        var bestScenario = device.Scenarios
-            .Where(s => s.Current)
-            .OrderByDescending(s => s.Probability)
-            .ThenByDescending(s => s.Confidence)
-            .ThenBy(s => device.Scenarios.IndexOf(s))
-            .FirstOrDefault();
+        mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}", "not_home", false))
+                .Returns(Task.CompletedTask)
+                .Verifiable();
 
-        device.BestScenario = bestScenario;
+        // Act
+        await locator.ProcessDevice(device);
 
-        if (bestScenario != null)
-        {
-            var newState = device.Room?.Name ?? device.Floor?.Name ?? "not_home";
-            if (newState != device.ReportedState)
-            {
-                device.ReportedState = newState;
-            }
-        }
-        else if (device.ReportedState != "not_home")
-        {
-            device.ReportedState = "not_home";
-        }
-
+        // Assert
         Assert.That(device.ReportedState, Is.EqualTo("not_home"));
+        mqttMock.Verify();
     }
 }
+

--- a/tests/MultiScenarioLocatorTests.cs
+++ b/tests/MultiScenarioLocatorTests.cs
@@ -1,0 +1,51 @@
+using ESPresense.Models;
+using ESPresense.Locators;
+
+namespace ESPresense.Companion.Tests;
+
+public class MultiScenarioLocatorTests
+{
+    private class DummyLocator : ILocate
+    {
+        public bool Locate(Scenario scenario) => true;
+    }
+
+    [Test]
+    public void NotHomeStateWhenAllScenariosExpire()
+    {
+        var device = new Device("id", null, TimeSpan.FromSeconds(1))
+        {
+            ReportedState = "kitchen"
+        };
+
+        var scenario = new Scenario(null, new DummyLocator(), "kitchen")
+        {
+            LastHit = DateTime.UtcNow.AddSeconds(-5)
+        };
+        device.Scenarios.Add(scenario);
+
+        var bestScenario = device.Scenarios
+            .Where(s => s.Current)
+            .OrderByDescending(s => s.Probability)
+            .ThenByDescending(s => s.Confidence)
+            .ThenBy(s => device.Scenarios.IndexOf(s))
+            .FirstOrDefault();
+
+        device.BestScenario = bestScenario;
+
+        if (bestScenario != null)
+        {
+            var newState = device.Room?.Name ?? device.Floor?.Name ?? "not_home";
+            if (newState != device.ReportedState)
+            {
+                device.ReportedState = newState;
+            }
+        }
+        else if (device.ReportedState != "not_home")
+        {
+            device.ReportedState = "not_home";
+        }
+
+        Assert.That(device.ReportedState, Is.EqualTo("not_home"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure not_home is published when no scenarios are active
- add unit test covering not_home behaviour

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_683f90a3a2248324a4bb0ddfce768879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Devices now correctly update their state to "not_home" and communicate this via MQTT when no valid scenario is detected.

- **Tests**
  - Added a new test to verify that devices are set to "not_home" when all scenarios have expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->