### PR TITLE
Add pnpm install step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       with:
         dotnet-version: 8.0.x
 
+    - name: Enable pnpm via Corepack
+      run: corepack enable
+
+    - name: Install pnpm
+      run: |
+        corepack prepare pnpm@latest --activate
+        pnpm --version
+
     - name: Restore dependencies
       run: dotnet restore
 


### PR DESCRIPTION
## Summary
- enable pnpm via corepack
- explicitly install pnpm and print version in CI workflow

## Testing
- `dotnet test -c Release --no-build --verbosity normal --filter "Category!=LongRunning"` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840293205688324b21c1535c2f8acd5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CI workflow to enable and install the latest version of pnpm using Corepack before restoring dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->