### PR TITLE
Improve firmware update UI

### DIFF
--- a/src/ui/src/lib/NodeActions.svelte
+++ b/src/ui/src/lib/NodeActions.svelte
@@ -211,7 +211,7 @@
 		<button class="btn btn-sm variant-filled-secondary" on:click|stopPropagation={() => detail(row)} aria-label="View node on map"> Map </button>
 
 		{#if row.telemetry?.version}
-			<button on:click={() => onUpdate(row)} disabled={!($updateMethod === 'self' || ($firmwareSource === 'release' && $version) || ($firmwareSource === 'artifact' && $artifact))} class="btn btn-sm variant-filled-tertiary" aria-label="Update node firmware"> Update </button>
+			<button on:click={() => onUpdate(row)} disabled={!$firmwareTypes || !($updateMethod === 'self' || ($firmwareSource === 'release' && $version) || ($firmwareSource === 'artifact' && $artifact))} class="btn btn-sm variant-filled-tertiary" aria-label="Update node firmware"> Update </button>
 		{/if}
 
 		{#if row.telemetry}

--- a/src/ui/src/lib/VersionPicker.svelte
+++ b/src/ui/src/lib/VersionPicker.svelte
@@ -30,29 +30,37 @@
 				</select>
 				{#if firmwareSource === 'release'}
 					<label for="version" class="whitespace-nowrap">Version:</label>
-					<select id="version" class="flex-grow select" bind:value={version}>
-						{#each Array.from($releases.entries()).reverse() as [key, value]}
-							<optgroup label={key}>
-								{#each value as item}
-									<option value={item.tag_name}>{item.name}</option>
-								{/each}
-							</optgroup>
-						{/each}
-					</select>
+					{#if $releases.size === 0}
+						<span>Loading...</span>
+					{:else}
+						<select id="version" class="flex-grow select" bind:value={version}>
+							{#each Array.from($releases.entries()).reverse() as [key, value]}
+								<optgroup label={key}>
+									{#each value as item}
+										<option value={item.tag_name}>{item.name}</option>
+									{/each}
+								</optgroup>
+							{/each}
+						</select>
+					{/if}
 				{/if}
 				{#if firmwareSource === 'artifact'}
 					<label for="artifact" class="whitespace-nowrap">Artifact:</label>
-					<select id="artifact" class="select" bind:value={artifact}>
-						{#each Array.from($artifacts.entries()).reverse() as [key, value]}
-							<optgroup label={key}>
-								{#each value as item}
-									<option value={item.id}>
-										{item.head_sha.substring(0, 7)}: {item.head_commit.message.split('\n')[0]}
-									</option>
-								{/each}
-							</optgroup>
-						{/each}
-					</select>
+					{#if $artifacts.size === 0}
+						<span>Loading...</span>
+					{:else}
+						<select id="artifact" class="select" bind:value={artifact}>
+							{#each Array.from($artifacts.entries()).reverse() as [key, value]}
+								<optgroup label={key}>
+									{#each value as item}
+										<option value={item.id}>
+											{item.head_sha.substring(0, 7)}: {item.head_commit.message.split('\n')[0]}
+										</option>
+									{/each}
+								</optgroup>
+							{/each}
+						</select>
+					{/if}
 				{/if}
 			</div>
 		{/if}


### PR DESCRIPTION
## Summary
- prevent firmware update until firmware list loads
- show loading indicator for release/artifact lists

## Testing
- `npm run lint`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_685fd15ca90883248a0898477d22107e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators for firmware version and artifact dropdowns, providing clearer feedback while data is being fetched.

* **Bug Fixes**
  * Improved update button logic to require available firmware types before enabling the update action, preventing unintended updates when firmware types are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->