### PR TITLE
ci: cache pnpm store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       with:
         version: 10
         run_install: false
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.pnpm-store
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
   
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
## Summary
- cache pnpm store in CI workflow for faster front-end installs

## Testing
- `dotnet test -c Release --verbosity minimal --filter "Category!=LongRunning"`
- `pnpm -C src/ui lint` *(fails: Code style issues found in 29 files)*
- `pnpm -C src/ui test:unit` *(fails: Command failed with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3af3b9348324b5cd1b1346d8b012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Improved CI pipeline by adding caching for pnpm dependencies to reduce install times and speed up builds.
  * Optimized step order to leverage the cache earlier in the build for higher hit rates and more consistent performance.
  * Results in faster feedback cycles and improved reliability of continuous integration runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->