### PR TITLE
ci: cache Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,14 @@ jobs:
     - name: Install frontend dependencies
       run: pnpm -C src/ui install --frozen-lockfile
 
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('src/ui/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
+
     - name: Install Playwright
       run: pnpm -C src/ui exec playwright install --with-deps
 


### PR DESCRIPTION
## Summary
- cache Playwright browser binaries in CI to speed up frontend tests

## Testing
- `dotnet test`
- `pnpm -C src/ui lint`
- `pnpm -C src/ui test`


------
https://chatgpt.com/codex/tasks/task_e_68bc428f33708324a2e1c4cc7c42f73e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline by caching Playwright browser binaries between runs, significantly reducing setup time for UI tests and accelerating build times. The cache uses OS-aware keys with restore fallbacks to improve hit rates across runs. This change affects only the build infrastructure; there are no changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->