### PR TITLE
Implement device deletion functionality and cleanup service

### DIFF
--- a/src/Controllers/StateController.cs
+++ b/src/Controllers/StateController.cs
@@ -173,6 +173,7 @@ public class StateController : ControllerBase
         void OnConfigChanged(object? sender, Config e) => EnqueueAndSignal(new { type = "configChanged" });
         void OnCalibrationChanged(object? sender, CalibrationEventArgs e) => EnqueueAndSignal(new { type = "calibrationChanged", data = e.Calibration });
         void OnNodeStateChanged(object? sender, NodeStateEventArgs e) => EnqueueAndSignal(new { type = "nodeStateChanged", data = e.NodeState });
+        void OnDeviceRemoved(object? sender, DeviceRemovedEventArgs e) => EnqueueAndSignal(new { type = "deviceRemoved", deviceId = e.DeviceId });
         void OnDeviceChanged(object? sender, DeviceEventArgs e)
         {
             if (showAll || (e.Device?.Track ?? false) || e.TrackChanged)
@@ -203,7 +204,7 @@ public class StateController : ControllerBase
         _eventDispatcher.NodeStateChanged += OnNodeStateChanged;
         _eventDispatcher.DeviceStateChanged += OnDeviceChanged;
         _eventDispatcher.DeviceMessageReceived += OnDeviceMessageReceived;
-        _eventDispatcher.DeviceRemoved += (_, e) => EnqueueAndSignal(new { type = "deviceRemoved", deviceId = e.DeviceId });
+        _eventDispatcher.DeviceRemoved += OnDeviceRemoved;
 
         try
         {

--- a/src/Controllers/StateController.cs
+++ b/src/Controllers/StateController.cs
@@ -203,6 +203,7 @@ public class StateController : ControllerBase
         _eventDispatcher.NodeStateChanged += OnNodeStateChanged;
         _eventDispatcher.DeviceStateChanged += OnDeviceChanged;
         _eventDispatcher.DeviceMessageReceived += OnDeviceMessageReceived;
+        _eventDispatcher.DeviceRemoved += (_, e) => EnqueueAndSignal(new { type = "deviceRemoved", deviceId = e.DeviceId });
 
         try
         {

--- a/src/Controllers/StateController.cs
+++ b/src/Controllers/StateController.cs
@@ -303,6 +303,7 @@ public class StateController : ControllerBase
             _eventDispatcher.NodeStateChanged -= OnNodeStateChanged;
             _eventDispatcher.DeviceStateChanged -= OnDeviceChanged;
             _eventDispatcher.DeviceMessageReceived -= OnDeviceMessageReceived;
+            _eventDispatcher.DeviceRemoved -= OnDeviceRemoved;
         }
     }
 

--- a/src/Events/GlobalEventDispatcher.cs
+++ b/src/Events/GlobalEventDispatcher.cs
@@ -9,6 +9,7 @@ public class GlobalEventDispatcher()
     public event EventHandler<NodeStateEventArgs>? NodeStateChanged;
     public event EventHandler<DeviceEventArgs>? DeviceStateChanged;
     public event EventHandler<CalibrationEventArgs>? CalibrationChanged;
+    public event EventHandler<DeviceRemovedEventArgs>? DeviceRemoved;
 
     public void OnNodeStateChanged(NodeState state)
     {
@@ -29,6 +30,11 @@ public class GlobalEventDispatcher()
     {
         DeviceMessageReceived?.Invoke(this, e);
     }
+
+    public void OnDeviceRemoved(string deviceId)
+    {
+        DeviceRemoved?.Invoke(this, new DeviceRemovedEventArgs(deviceId));
+    }
 }
 
 public class NodeStateEventArgs(NodeState state) : EventArgs
@@ -45,4 +51,9 @@ public class DeviceEventArgs(Device device, bool trackChanged) : EventArgs
 public class CalibrationEventArgs(Calibration calibration) : EventArgs
 {
     public Calibration Calibration { get; } = calibration;
+}
+
+public class DeviceRemovedEventArgs(string deviceId) : EventArgs
+{
+    public string DeviceId { get; } = deviceId;
 }

--- a/src/Extensions/TimeSpanExtensions.cs
+++ b/src/Extensions/TimeSpanExtensions.cs
@@ -1,8 +1,16 @@
 namespace ESPresense.Extensions
 {
+    public enum DurationUnit
+    {
+        Seconds,
+        Minutes, 
+        Hours,
+        Days
+    }
+
     public static class TimeSpanExtensions
     {
-        public static bool TryParseDurationString(this string input, out TimeSpan ts)
+        public static bool TryParseDurationString(this string input, out TimeSpan ts, DurationUnit defaultUnit = DurationUnit.Seconds)
         {
             ts = default(TimeSpan);
             if (string.IsNullOrWhiteSpace(input))
@@ -10,15 +18,22 @@ namespace ESPresense.Extensions
 
             var total = TimeSpan.Zero;
             var currentNumber = 0;
+            var hasExplicitUnits = false;
+            var hasReadDigits = false; // Track if we've read any digits for current number
 
             foreach (var c in input)
             {
                 if (char.IsDigit(c))
                 {
                     currentNumber = currentNumber * 10 + (c - '0');
+                    hasReadDigits = true;
                 }
                 else
                 {
+                    if (!hasReadDigits)
+                        return false; // Found unit without any preceding digits (e.g., "s30")
+                    
+                    hasExplicitUnits = true;
                     switch (char.ToLower(c))
                     {
                         case 'd':
@@ -37,11 +52,34 @@ namespace ESPresense.Extensions
                             return false;
                     }
                     currentNumber = 0;
+                    hasReadDigits = false; // Reset for next number
                 }
+            }
+
+            // Handle any remaining number without unit
+            if (hasReadDigits)
+            {
+                // If we had explicit units but also have a unitless number, that's ambiguous - reject it
+                if (hasExplicitUnits)
+                    return false;
+
+                // Use default unit for purely unitless input
+                total = defaultUnit switch
+                {
+                    DurationUnit.Days => total.Add(TimeSpan.FromDays(currentNumber)),
+                    DurationUnit.Hours => total.Add(TimeSpan.FromHours(currentNumber)),
+                    DurationUnit.Minutes => total.Add(TimeSpan.FromMinutes(currentNumber)),
+                    DurationUnit.Seconds => total.Add(TimeSpan.FromSeconds(currentNumber)),
+                    _ => total.Add(TimeSpan.FromSeconds(currentNumber))
+                };
             }
 
             ts = total;
             return true;
         }
+
+        // Backward compatibility overload
+        public static bool TryParseDurationString(this string input, out TimeSpan ts) =>
+            TryParseDurationString(input, out ts, DurationUnit.Seconds);
     }
 }

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -51,7 +51,7 @@ namespace ESPresense.Models
         public string DeviceRetention { get; set; } = "30d";
 
         [YamlIgnore]
-        public TimeSpan DeviceRetentionTimeSpan => DeviceRetention.TryParseDurationString(out var ts) ? ts : TimeSpan.FromDays(30);
+        public TimeSpan DeviceRetentionTimeSpan => DeviceRetention.TryParseDurationString(out var ts, DurationUnit.Days) ? ts : TimeSpan.FromDays(30);
     }
 
     public partial class ConfigLocators

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -45,6 +45,13 @@ namespace ESPresense.Models
 
         [YamlMember(Alias = "optimization")]
         public ConfigOptimization Optimization { get; set; } = new();
+
+        // Retention policy for inactive devices (duration string, e.g., "30d", "720h")
+        [YamlMember(Alias = "device_retention")]
+        public string DeviceRetention { get; set; } = "30d";
+
+        [YamlIgnore]
+        public TimeSpan DeviceRetentionTimeSpan => DeviceRetention.TryParseDurationString(out var ts) ? ts : TimeSpan.FromDays(30);
     }
 
     public partial class ConfigLocators

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -75,6 +75,7 @@ builder.Services.AddHostedService(provider => provider.GetRequiredService<Device
 builder.Services.AddHostedService(provider => provider.GetRequiredService<NodeSettingsStore>());
 builder.Services.AddHostedService(provider => provider.GetRequiredService<NodeTelemetryStore>());
 builder.Services.AddHostedService(provider => provider.GetRequiredService<TelemetryService>());
+builder.Services.AddHostedService<DeviceCleanupService>();
 builder.Services.AddSingleton<State>();
 builder.Services.AddControllersWithViews().AddJsonOptions(opt =>
 {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -67,6 +67,7 @@ builder.Services.AddSingleton<DeviceSettingsStore>();
 builder.Services.AddSingleton<NodeSettingsStore>();
 builder.Services.AddSingleton<NodeTelemetryStore>();
 builder.Services.AddSingleton<FirmwareTypeStore>();
+builder.Services.AddSingleton<DeviceService>();
 
 builder.Services.AddHostedService<MultiScenarioLocator>();
 builder.Services.AddHostedService<OptimizationRunner>();

--- a/src/Services/DeviceCleanupService.cs
+++ b/src/Services/DeviceCleanupService.cs
@@ -1,6 +1,4 @@
-using ESPresense.Controllers;
 using ESPresense.Models;
-using Serilog;
 using Microsoft.Extensions.Logging;
 
 namespace ESPresense.Services;
@@ -8,7 +6,7 @@ namespace ESPresense.Services;
 /// <summary>
 /// Background service that periodically removes devices that have not been seen for a configured retention period.
 /// </summary>
-public class DeviceCleanupService(State state, MqttCoordinator mqtt, GlobalEventDispatcher events, ILogger<DeviceCleanupService> logger) : BackgroundService
+public class DeviceCleanupService(State state, DeviceService deviceService, ILogger<DeviceCleanupService> logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -34,60 +32,17 @@ public class DeviceCleanupService(State state, MqttCoordinator mqtt, GlobalEvent
             var retention = state.Config?.DeviceRetentionTimeSpan ?? TimeSpan.FromDays(30);
             var cutoff = DateTime.UtcNow - retention;
 
-            DateTime? NormalizeUtc(DateTime? dt)
-            {
-                if (dt == null) return null;
-                var v = dt.Value;
-                return v.Kind switch
-                {
-                    DateTimeKind.Utc => v,
-                    DateTimeKind.Local => v.ToUniversalTime(),
-                    _ => DateTime.SpecifyKind(v, DateTimeKind.Utc)
-                };
-            }
+            var inactiveDevices = deviceService.GetInactiveDevices(cutoff).ToList();
+            var total = deviceService.GetAllDevices().Count();
 
-            var toRemove = new List<Device>();
-            foreach (var d in state.Devices.Values)
-            {
-                // Use LastSeen exclusively; this is restored at startup from retained attributes
-                var lastSeen = NormalizeUtc(d.LastSeen);
-                if (lastSeen.HasValue && lastSeen.Value < cutoff)
-                {
-                    toRemove.Add(d);
-                }
-            }
-
-            var total = state.Devices.Count;
-            if (toRemove.Count == 0)
+            if (inactiveDevices.Count == 0)
             {
                 logger.LogInformation("DeviceCleanup: evaluated {Total} devices; 0 removals. Cutoff={Cutoff:o}", total, cutoff);
                 return;
             }
 
-            var removedCount = 0;
-            foreach (var d in toRemove)
-            {
-                if (state.Devices.TryRemove(d.Id, out var removed))
-                {
-                    removedCount++;
-                    try
-                    {
-                        foreach (var ad in removed.HassAutoDiscovery)
-                        {
-                            await ad.Delete(mqtt);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex, "DeviceCleanup: failed HA discovery delete for {DeviceId}", removed.Id);
-                    }
-
-                    // Notify connected clients to drop device immediately
-                    events.OnDeviceRemoved(removed.Id);
-
-                    Log.Information("[x] Auto-deleted device {DeviceId} last seen {LastSeen}", removed.Id, removed.LastSeen?.ToLocalTime());
-                }
-            }
+            var deviceIds = inactiveDevices.Select(d => d.Id).ToList();
+            var removedCount = await deviceService.DeleteBulkAsync(deviceIds, "auto-cleanup");
 
             logger.LogInformation("DeviceCleanup: evaluated {Total} devices; removed {Removed}. Cutoff={Cutoff:o}", total, removedCount, cutoff);
         }

--- a/src/Services/DeviceCleanupService.cs
+++ b/src/Services/DeviceCleanupService.cs
@@ -1,0 +1,99 @@
+using ESPresense.Controllers;
+using ESPresense.Models;
+using Serilog;
+using Microsoft.Extensions.Logging;
+
+namespace ESPresense.Services;
+
+/// <summary>
+/// Background service that periodically removes devices that have not been seen for a configured retention period.
+/// </summary>
+public class DeviceCleanupService(State state, MqttCoordinator mqtt, GlobalEventDispatcher events, ILogger<DeviceCleanupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var retention = state.Config?.DeviceRetentionTimeSpan ?? TimeSpan.FromDays(30);
+        logger.LogInformation("DeviceCleanup: starting. Retention={Retention}", retention);
+
+        // Give MQTT attribute restoration a moment to populate LastSeen
+        try { await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken); } catch (TaskCanceledException) { }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await RunCleanup(stoppingToken);
+
+            try { await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken); }
+            catch (TaskCanceledException) { /* ignored */ }
+        }
+    }
+
+    private async Task RunCleanup(CancellationToken stoppingToken)
+    {
+        try
+        {
+            var retention = state.Config?.DeviceRetentionTimeSpan ?? TimeSpan.FromDays(30);
+            var cutoff = DateTime.UtcNow - retention;
+
+            DateTime? NormalizeUtc(DateTime? dt)
+            {
+                if (dt == null) return null;
+                var v = dt.Value;
+                return v.Kind switch
+                {
+                    DateTimeKind.Utc => v,
+                    DateTimeKind.Local => v.ToUniversalTime(),
+                    _ => DateTime.SpecifyKind(v, DateTimeKind.Utc)
+                };
+            }
+
+            var toRemove = new List<Device>();
+            foreach (var d in state.Devices.Values)
+            {
+                // Use LastSeen exclusively; this is restored at startup from retained attributes
+                var lastSeen = NormalizeUtc(d.LastSeen);
+                if (lastSeen.HasValue && lastSeen.Value < cutoff)
+                {
+                    toRemove.Add(d);
+                }
+            }
+
+            var total = state.Devices.Count;
+            if (toRemove.Count == 0)
+            {
+                logger.LogInformation("DeviceCleanup: evaluated {Total} devices; 0 removals. Cutoff={Cutoff:o}", total, cutoff);
+                return;
+            }
+
+            var removedCount = 0;
+            foreach (var d in toRemove)
+            {
+                if (state.Devices.TryRemove(d.Id, out var removed))
+                {
+                    removedCount++;
+                    try
+                    {
+                        foreach (var ad in removed.HassAutoDiscovery)
+                        {
+                            await ad.Delete(mqtt);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "DeviceCleanup: failed HA discovery delete for {DeviceId}", removed.Id);
+                    }
+
+                    // Notify connected clients to drop device immediately
+                    events.OnDeviceRemoved(removed.Id);
+
+                    Log.Information("[x] Auto-deleted device {DeviceId} last seen {LastSeen}", removed.Id, removed.LastSeen?.ToLocalTime());
+                }
+            }
+
+            logger.LogInformation("DeviceCleanup: evaluated {Total} devices; removed {Removed}. Cutoff={Cutoff:o}", total, removedCount, cutoff);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error running device cleanup");
+        }
+    }
+}

--- a/src/Services/DeviceService.cs
+++ b/src/Services/DeviceService.cs
@@ -1,0 +1,163 @@
+using ESPresense.Controllers;
+using ESPresense.Models;
+using Microsoft.Extensions.Logging;
+
+namespace ESPresense.Services;
+
+/// <summary>
+/// Service that handles common device operations including deletion, cleanup, and management.
+/// </summary>
+public class DeviceService
+{
+    private readonly State _state;
+    private readonly MqttCoordinator _mqtt;
+    private readonly GlobalEventDispatcher _events;
+    private readonly ILogger<DeviceService> _logger;
+
+    public DeviceService(State state, MqttCoordinator mqtt, GlobalEventDispatcher events, ILogger<DeviceService> logger)
+    {
+        _state = state;
+        _mqtt = mqtt;
+        _events = events;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Deletes a device and performs all necessary cleanup operations.
+    /// </summary>
+    /// <param name="deviceId">The ID of the device to delete</param>
+    /// <param name="source">The source of the deletion (e.g., "manual", "auto-cleanup")</param>
+    /// <returns>True if the device was found and deleted, false if not found</returns>
+    public async Task<bool> DeleteAsync(string deviceId, string source = "manual")
+    {
+        if (string.IsNullOrWhiteSpace(deviceId))
+        {
+            _logger.LogWarning("Attempted to delete device with null or empty ID");
+            return false;
+        }
+
+        if (!_state.Devices.TryRemove(deviceId, out var device))
+        {
+            _logger.LogDebug("Device {DeviceId} not found for deletion", deviceId);
+            return false;
+        }
+
+        await PerformDeviceCleanup(device, source);
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes multiple devices in bulk and performs cleanup operations.
+    /// </summary>
+    /// <param name="deviceIds">Collection of device IDs to delete</param>
+    /// <param name="source">The source of the deletion</param>
+    /// <returns>Number of devices successfully deleted</returns>
+    public async Task<int> DeleteBulkAsync(IEnumerable<string> deviceIds, string source = "bulk")
+    {
+        var deletedCount = 0;
+        var devices = new List<Device>();
+
+        // First, remove all devices from state
+        foreach (var deviceId in deviceIds)
+        {
+            if (!string.IsNullOrWhiteSpace(deviceId) && _state.Devices.TryRemove(deviceId, out var device))
+            {
+                devices.Add(device);
+                deletedCount++;
+            }
+        }
+
+        // Then perform cleanup for all removed devices
+        foreach (var device in devices)
+        {
+            await PerformDeviceCleanup(device, source);
+        }
+
+        if (deletedCount > 0)
+        {
+            _logger.LogInformation("Bulk deleted {Count} devices via {Source}", deletedCount, source);
+        }
+
+        return deletedCount;
+    }
+
+    /// <summary>
+    /// Gets devices that haven't been seen since the specified cutoff time.
+    /// </summary>
+    /// <param name="cutoffTime">Devices last seen before this time are considered inactive</param>
+    /// <returns>Collection of inactive devices</returns>
+    public IEnumerable<Device> GetInactiveDevices(DateTime cutoffTime)
+    {
+        return _state.Devices.Values.Where(device =>
+        {
+            var lastSeen = NormalizeUtc(device.LastSeen);
+            return lastSeen.HasValue && lastSeen.Value < cutoffTime;
+        });
+    }
+
+    /// <summary>
+    /// Gets a device by ID.
+    /// </summary>
+    /// <param name="deviceId">The device ID</param>
+    /// <returns>The device if found, null otherwise</returns>
+    public Device? GetDevice(string deviceId)
+    {
+        return string.IsNullOrWhiteSpace(deviceId) ? null : _state.Devices.GetValueOrDefault(deviceId);
+    }
+
+    /// <summary>
+    /// Gets all devices.
+    /// </summary>
+    /// <returns>Collection of all devices</returns>
+    public IEnumerable<Device> GetAllDevices()
+    {
+        return _state.Devices.Values;
+    }
+
+    /// <summary>
+    /// Checks if a device exists.
+    /// </summary>
+    /// <param name="deviceId">The device ID</param>
+    /// <returns>True if the device exists, false otherwise</returns>
+    public bool DeviceExists(string deviceId)
+    {
+        return !string.IsNullOrWhiteSpace(deviceId) && _state.Devices.ContainsKey(deviceId);
+    }
+
+    private async Task PerformDeviceCleanup(Device device, string source)
+    {
+        try
+        {
+            // Clean up Home Assistant auto-discovery entries
+            foreach (var ad in device.HassAutoDiscovery)
+            {
+                await ad.Delete(_mqtt);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete HA auto-discovery entries for device {DeviceId}", device.Id);
+        }
+
+        // Notify connected clients to remove device immediately
+        _events.OnDeviceRemoved(device.Id);
+
+        _logger.LogInformation("Device {DeviceId} ({DeviceName}) deleted via {Source}, last seen: {LastSeen}", 
+            device.Id, 
+            device.Name ?? "unnamed", 
+            source, 
+            device.LastSeen?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? "never");
+    }
+
+    private static DateTime? NormalizeUtc(DateTime? dt)
+    {
+        if (dt == null) return null;
+        var v = dt.Value;
+        return v.Kind switch
+        {
+            DateTimeKind.Utc => v,
+            DateTimeKind.Local => v.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(v, DateTimeKind.Utc)
+        };
+    }
+}

--- a/src/Services/DeviceService.cs
+++ b/src/Services/DeviceService.cs
@@ -38,7 +38,7 @@ public class DeviceService
 
         if (!_state.Devices.TryRemove(deviceId, out var device))
         {
-            _logger.LogDebug("Device {DeviceId} not found for deletion", deviceId);
+            _logger.LogDebug("Device {DeviceId} not found for deletion", deviceId.Replace("\r", "").Replace("\n", ""));
             return false;
         }
 

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -26,6 +26,10 @@ timeout: 30
 # How long before device is considered away
 away_timeout: 120
 
+# Retain devices for this long since last seen (duration string)
+# Examples: "30d", "720h", "2592000s"
+device_retention: 30d
+
 optimization:
   enabled: true
   interval_secs: 3600
@@ -251,8 +255,7 @@ devices:
   - id: "iBeacon:*"
   - id: "car:*"
   - id: "laptop:*"
-  - id: "itag:f0f010303080"
-    name: "Piper's Backpack"
+  - id: "backpack:*"
 
 # Devices to NOT track
 exclude_devices:

--- a/src/ui/src/lib/DeviceActions.svelte
+++ b/src/ui/src/lib/DeviceActions.svelte
@@ -2,7 +2,7 @@
 	import { base } from '$app/paths';
 	import { detail, calibrateDevice } from '$lib/urls';
 	import { getToastStore } from '$lib/toast/toastStore';
-	import { showComponent } from '$lib/modal/modalStore';
+	import { showComponent, showConfirm } from '$lib/modal/modalStore';
 	import type { Device, DeviceSetting, DeviceSettingsDetails } from '$lib/types';
 	import DeviceSettingsModal from './DeviceSettingsModal.svelte';
 
@@ -12,6 +12,7 @@
 
 	const toastStore = getToastStore();
 	let loadingEdit = false;
+    let loadingDelete = false;
 
 	// Determine if device is active based on lastSeen and timeout
 	$: isActive = row.lastSeen && new Date().getTime() - new Date(row.lastSeen).getTime() < (row.timeout || 30000);
@@ -45,6 +46,30 @@
 			loadingEdit = false;
 		}
 	}
+
+    async function handleDelete() {
+        if (!row?.id) return;
+        const confirmed = await showConfirm({
+            title: 'Delete Device',
+            body: `Are you sure you want to delete "${row.name || row.id}"? This cannot be undone.`
+        });
+        if (!confirmed) return;
+
+        loadingDelete = true;
+        try {
+            const resp = await fetch(`${base}/api/device/${encodeURIComponent(row.id)}`, { method: 'DELETE' });
+            if (!resp.ok && resp.status !== 204) {
+                throw new Error(`Failed to delete: ${resp.status} ${resp.statusText}`);
+            }
+            toastStore.trigger({ message: 'Device deleted', background: 'preset-filled-success-500' });
+        } catch (ex) {
+            console.error('Delete failed', ex);
+            const message = ex instanceof Error ? ex.message : 'Unknown error';
+            toastStore.trigger({ message: `Delete failed: ${message}`, background: 'preset-filled-error-500' });
+        } finally {
+            loadingDelete = false;
+        }
+    }
 </script>
 
 <div class="flex gap-1">
@@ -59,4 +84,11 @@
 		<button class="btn btn-sm preset-filled-secondary-500" on:click|stopPropagation={() => detail(row)} aria-label="View device on map"> Map </button>
 		<button class="btn btn-sm preset-filled-tertiary-500" on:click|stopPropagation={() => calibrateDevice(row)} aria-label="Calibrate device"> Calibrate </button>
 	{/if}
+    <button class="btn btn-sm bg-error-500 hover:bg-error-600 text-white" on:click|stopPropagation={handleDelete} disabled={loadingDelete} aria-label="Delete device">
+        {#if loadingDelete}
+            <span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
+        {:else}
+            Delete
+        {/if}
+    </button>
 </div>

--- a/src/ui/src/lib/DeviceCalibrationManager.svelte
+++ b/src/ui/src/lib/DeviceCalibrationManager.svelte
@@ -12,7 +12,7 @@
 	// Filter devices based on activity status
 	$: filteredDevices = $devices?.filter(device => {
 		if (showInactiveDevices) return true;
-		
+
 		// Check if device is active based on lastSeen and timeout
 		if (device.lastSeen == null) return false;
 		const timeout = device.timeout !== null && device.timeout !== undefined ? device.timeout : 30000;
@@ -94,15 +94,6 @@
 				const configured = d['rssi@1m'];
 				let color = 'text-surface-600-300';
 				let text = formatRssi(measured);
-				
-				// Add visual indication if values differ significantly
-				if (measured !== null && measured !== undefined && 
-					configured !== null && configured !== undefined && 
-					Math.abs(measured - configured) > 5) {
-					color = 'text-warning-500';
-					text += ' ⚠️';
-				}
-				
 				return `<span class="${color}">${text}</span>`;
 			}
 		},
@@ -177,9 +168,9 @@
 		<div class="card p-4">
 			<header class="text-lg font-semibold mb-4">Device Calibration Status</header>
 			{#if filteredDevices.length > 0}
-				<DataTable 
-					{columns} 
-					rows={filteredDevices} 
+				<DataTable
+					{columns}
+					rows={filteredDevices}
 					classNameTable="table table-compact"
 					on:clickRow={onRowClick}
 				/>
@@ -195,9 +186,6 @@
 			<header class="font-semibold mb-2">Instructions</header>
 			<ul class="list-disc pl-6 space-y-1 text-sm">
 				<li>Click "Calibrate" or click on an active device row to start calibration</li>
-				<li><strong>Configured RSSI@1m</strong>: Manually set calibration values that determine calibration status</li>
-				<li><strong>Measured RSSI@1m</strong>: Real-time averages from active nodes (for reference/validation)</li>
-				<li>⚠️ indicates significant difference between configured and measured values</li>
 				<li>Devices marked "Not Calibrated" should be calibrated for optimal accuracy</li>
 				<li>Only active devices (recently seen) can be calibrated</li>
 			</ul>

--- a/src/ui/src/lib/stores.ts
+++ b/src/ui/src/lib/stores.ts
@@ -111,6 +111,15 @@ export const devices = readable<Device[]>([], function start(set) {
 	};
 	wsManager.subscribeToEvent('deviceChanged', deviceChangedCallback);
 
+    const deviceRemovedCallback = (payload: any) => {
+        const id = payload?.deviceId || payload?.id || payload;
+        if (id && deviceMap.has(id)) {
+            deviceMap.delete(id);
+            updateDevicesFromMap();
+        }
+    };
+    wsManager.subscribeToEvent('deviceRemoved', deviceRemovedCallback);
+
 	const configChangedCallback = (data: Config) => {
 		getConfig();
 	};
@@ -136,6 +145,7 @@ export const devices = readable<Device[]>([], function start(set) {
 	return () => {
 		clearInterval(pollTimer);
 		wsManager.unsubscribeFromEvent('deviceChanged', deviceChangedCallback);
+        wsManager.unsubscribeFromEvent('deviceRemoved', deviceRemovedCallback);
 		wsManager.unsubscribeFromEvent('configChanged', configChangedCallback);
 		wsManager.unsubscribeFromEvent('time', timeCallback);
 		unsubscribeShowUntracked();

--- a/tests/TimeSpanExtensionsTests.cs
+++ b/tests/TimeSpanExtensionsTests.cs
@@ -29,4 +29,106 @@ public class TimeSpanExtensionsTests
         Assert.IsFalse(result);
         Assert.That(ts, Is.EqualTo(default(TimeSpan)));
     }
+
+    [TestCase("30s", 30, 0, 0, 0)]
+    [TestCase("5m", 0, 5, 0, 0)]
+    [TestCase("2h", 0, 0, 2, 0)]
+    [TestCase("7d", 0, 0, 0, 7)]
+    public void TryParseDurationString_SimpleUnits_ReturnsCorrectTimeSpan(string input, int seconds, int minutes, int hours, int days)
+    {
+        Assert.IsTrue(input.TryParseDurationString(out var result));
+        var expected = new TimeSpan(days, hours, minutes, seconds);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase("120", DurationUnit.Seconds, 120)]
+    [TestCase("30", DurationUnit.Days, 2592000)] // 30 days in seconds
+    [TestCase("48", DurationUnit.Hours, 172800)] // 48 hours in seconds  
+    [TestCase("90", DurationUnit.Minutes, 5400)] // 90 minutes in seconds
+    public void TryParseDurationString_DefaultUnits_ReturnsCorrectTimeSpan(string input, DurationUnit defaultUnit, int expectedSeconds)
+    {
+        Assert.IsTrue(input.TryParseDurationString(out var result, defaultUnit));
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(expectedSeconds)));
+    }
+
+    [Test]
+    public void TryParseDurationString_DefaultUnitBackwardCompatibility_ReturnsCorrectTimeSpan()
+    {
+        Assert.IsTrue("120".TryParseDurationString(out var result));
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(120)));
+    }
+
+    [TestCase("30s10")]
+    [TestCase("1h30")]
+    [TestCase("2d5")]
+    [TestCase("5m120")]
+    public void TryParseDurationString_MixedExplicitAndUnitless_ReturnsFalse(string input)
+    {
+        // These should fail because mixing explicit units with unitless numbers is ambiguous
+        Assert.IsFalse(input.TryParseDurationString(out var _));
+        Assert.IsFalse(input.TryParseDurationString(out var _, DurationUnit.Days));
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("abc")]
+    [TestCase("30x")] // Invalid unit
+    [TestCase("s30")] // Unit before number
+    [TestCase("30ss")] // Double unit
+    public void TryParseDurationString_InvalidFormats_ReturnsFalse(string input)
+    {
+        Assert.IsFalse(input.TryParseDurationString(out var _));
+    }
+
+    [Test]
+    public void TryParseDurationString_NullInput_ReturnsFalse()
+    {
+        Assert.IsFalse(((string)null).TryParseDurationString(out var _));
+    }
+
+    [TestCase("30S", 30, 0, 0, 0)]
+    [TestCase("5M", 0, 5, 0, 0)]
+    [TestCase("2H", 0, 0, 2, 0)]
+    [TestCase("7D", 0, 0, 0, 7)]
+    public void TryParseDurationString_CaseInsensitive_ReturnsCorrectTimeSpan(string input, int seconds, int minutes, int hours, int days)
+    {
+        Assert.IsTrue(input.TryParseDurationString(out var result));
+        var expected = new TimeSpan(days, hours, minutes, seconds);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase("0s")]
+    [TestCase("0")]
+    public void TryParseDurationString_ZeroValues_ReturnsZeroTimeSpan(string input)
+    {
+        Assert.IsTrue(input.TryParseDurationString(out var result));
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void TryParseDurationString_ZeroWithDefaultUnit_ReturnsZeroTimeSpan()
+    {
+        Assert.IsTrue("0".TryParseDurationString(out var result, DurationUnit.Days));
+        Assert.That(result, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [TestCase("365d", 365)]
+    [TestCase("8760h", 8760)]
+    public void TryParseDurationString_LargeNumbers_ReturnsCorrectTimeSpan(string input, int expectedValue)
+    {
+        Assert.IsTrue(input.TryParseDurationString(out var result));
+        var expected = input.EndsWith('d') ? TimeSpan.FromDays(expectedValue) : TimeSpan.FromHours(expectedValue);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void TryParseDurationString_BackwardCompatibility_WorksAsExpected()
+    {
+        // Test that existing calls without defaultUnit parameter still work
+        Assert.IsTrue("30".TryParseDurationString(out var result));
+        Assert.That(result, Is.EqualTo(TimeSpan.FromSeconds(30))); // Should default to seconds
+
+        Assert.IsTrue("1h30m".TryParseDurationString(out var result2));
+        Assert.That(result2, Is.EqualTo(TimeSpan.FromMinutes(90)));
+    }
 }


### PR DESCRIPTION
- Added DELETE endpoint in DeviceController to remove devices.
- Introduced DeviceCleanupService for periodic removal of inactive devices.
- Updated GlobalEventDispatcher to notify when a device is removed.
- Enhanced UI with delete confirmation and loading state in DeviceActions.svelte.
- Updated stores to handle device removal events from WebSocket.
- Added device retention configuration in Config model and example YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete devices from the UI with confirmation, toast feedback, and real-time removal updates.
  * Automatic background cleanup of inactive devices after a configurable retention period (default 30 days).
  * Server API endpoint for device deletion and real-time "deviceRemoved" notifications to clients.
  * Cleans up related Home Assistant auto-discovery entries when devices are removed.

* **Documentation**
  * Added device_retention setting to the example configuration with guidance.

* **Style**
  * Removed calibration discrepancy highlight and related instruction text.

* **Tests**
  * Added comprehensive tests for duration-string parsing used by retention settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->