### PR TITLE
Align device detail layout to avoid breadcrumb overflow

### DIFF
--- a/src/ui/src/routes/devices/[id]/+page.svelte
+++ b/src/ui/src/routes/devices/[id]/+page.svelte
@@ -55,19 +55,21 @@
 		<!-- Breadcrumb Navigation -->
 		<DeviceBreadcrumb deviceName={device?.name || device?.id || 'Unknown Device'} currentView={currentTab === 'calibration' ? 'calibration' : 'map'} />
 
-		<div class="flex-1 min-h-0 overflow-hidden">
-			{#if currentTab === 'map'}
+		{#if currentTab === 'map'}
+			<div class="grid flex-1 min-h-0">
 				<Map deviceId={data.settings?.id} floorId={device?.floor?.id} exclusive={true} />
-			{:else if currentTab === 'calibration'}
-				{#if data.settings?.id}
-					<div class="h-full overflow-auto">
-						<DeviceCalibration deviceSettings={data.settings} />
-					</div>
-				{:else}
+			</div>
+		{:else if currentTab === 'calibration'}
+			{#if data.settings?.id}
+				<div class="flex-1 min-h-0 overflow-auto">
+					<DeviceCalibration deviceSettings={data.settings} />
+				</div>
+			{:else}
+				<div class="flex-1 min-h-0">
 					<p class="p-4">Device ID not found.</p>
-				{/if}
+				</div>
 			{/if}
-		</div>
+		{/if}
 	</div>
 	<div class="w-64 flex-shrink-0 bg-surface-100-800 border-l border-surface-300-700 overflow-auto">
 		<Accordion value={accordionValue} onValueChange={(e) => (accordionValue = e.value)}>

--- a/src/ui/src/routes/devices/[id]/+page.svelte
+++ b/src/ui/src/routes/devices/[id]/+page.svelte
@@ -50,25 +50,24 @@
 	<title>ESPresense Companion: Device Detail</title>
 </svelte:head>
 
-<div class="flex h-full">
-	<div class="flex-grow overflow-auto">
+<div class="flex h-full min-h-0">
+	<div class="flex flex-col flex-grow min-h-0">
 		<!-- Breadcrumb Navigation -->
-		<DeviceBreadcrumb 
-			deviceName={device?.name || device?.id || 'Unknown Device'} 
-			currentView={currentTab === 'calibration' ? 'calibration' : 'map'} 
-		/>
-		
-		{#if currentTab === 'map'}
-			<div class="h-full">
+		<DeviceBreadcrumb deviceName={device?.name || device?.id || 'Unknown Device'} currentView={currentTab === 'calibration' ? 'calibration' : 'map'} />
+
+		<div class="flex-1 min-h-0 overflow-hidden">
+			{#if currentTab === 'map'}
 				<Map deviceId={data.settings?.id} floorId={device?.floor?.id} exclusive={true} />
-			</div>
-		{:else if currentTab === 'calibration'}
-			{#if data.settings?.id}
-				<DeviceCalibration deviceSettings={data.settings} />
-			{:else}
-				<p class="p-4">Device ID not found.</p>
+			{:else if currentTab === 'calibration'}
+				{#if data.settings?.id}
+					<div class="h-full overflow-auto">
+						<DeviceCalibration deviceSettings={data.settings} />
+					</div>
+				{:else}
+					<p class="p-4">Device ID not found.</p>
+				{/if}
 			{/if}
-		{/if}
+		</div>
 	</div>
 	<div class="w-64 flex-shrink-0 bg-surface-100-800 border-l border-surface-300-700 overflow-auto">
 		<Accordion value={accordionValue} onValueChange={(e) => (accordionValue = e.value)}>

--- a/src/ui/src/routes/nodes/[id]/+page.svelte
+++ b/src/ui/src/routes/nodes/[id]/+page.svelte
@@ -11,7 +11,7 @@
 	export let floorId: string | null = null;
 	export let data: NodeSettingDetails = {};
 	$: node = $nodes.find((d) => d.id === data.settings?.id);
-	
+
 	// Initialize floorId to the first floor the node is actually on
 	$: if (!floorId && node?.floors?.length > 0) {
 		floorId = node.floors[0];
@@ -46,13 +46,9 @@
 <div class="flex h-full min-h-0">
 	<div class="flex flex-col flex-grow min-h-0">
 		<!-- Breadcrumb Navigation -->
-		<NodeBreadcrumb
-			nodeName={node?.name || node?.id || 'Unknown Node'}
-			bind:currentFloorId={floorId}
-			{node}
-		/>
+		<NodeBreadcrumb nodeName={node?.name || node?.id || 'Unknown Node'} bind:currentFloorId={floorId} {node} />
 
-		<div class="flex-1 min-h-0 overflow-hidden">
+		<div class="grid flex-1 min-h-0">
 			<Map deviceId="none" nodeId={data.settings?.id} bind:floorId exclusive={true} />
 		</div>
 	</div>

--- a/src/ui/src/routes/nodes/[id]/+page.svelte
+++ b/src/ui/src/routes/nodes/[id]/+page.svelte
@@ -43,16 +43,16 @@
 	<title>ESPresense Companion: Node Detail</title>
 </svelte:head>
 
-<div class="flex h-full">
-	<div class="flex-grow overflow-auto">
+<div class="flex h-full min-h-0">
+	<div class="flex flex-col flex-grow min-h-0">
 		<!-- Breadcrumb Navigation -->
-		<NodeBreadcrumb 
-			nodeName={node?.name || node?.id || 'Unknown Node'} 
+		<NodeBreadcrumb
+			nodeName={node?.name || node?.id || 'Unknown Node'}
 			bind:currentFloorId={floorId}
 			{node}
 		/>
-		
-		<div class="h-full">
+
+		<div class="flex-1 min-h-0 overflow-hidden">
 			<Map deviceId="none" nodeId={data.settings?.id} bind:floorId exclusive={true} />
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- restructure the device detail layout so the breadcrumb no longer forces an extra scrollbar
- keep the map view flexible within the available height and wrap the calibration view in its own scroll container

## Testing
- pnpm -C src/ui lint *(fails: repository has existing Prettier formatting issues across many UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a3a545b08324801225da02116ecf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Reworked Devices and Nodes detail page layouts for more reliable sizing and overflow handling.
  - Left content now flexes to fill space and scrolls within the panel, reducing full-page scrolling.
  - Map and calibration views now size and scroll within their content areas for consistent rendering.
- New Features
  - Added a right-side details panel on the Device page that shows device details and auto-refreshes; shows loading/empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->