### PR TITLE
Fix bug with storing settings under wrong id

### DIFF
--- a/src/Controllers/DeviceController.cs
+++ b/src/Controllers/DeviceController.cs
@@ -32,9 +32,17 @@ namespace ESPresense.Controllers
         }
 
         [HttpPut("{id}")]
-        public async Task Set(string id, [FromBody] DeviceSettings value)
+        public async Task<IActionResult> Set(string id, [FromBody] DeviceSettings value)
         {
-            await _deviceSettingsStore.Set(id, value);
+            try
+            {
+                await _deviceSettingsStore.Set(id, value);
+                return Ok();
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
         }
 
         [HttpDelete("{id}")]

--- a/src/ui/src/lib/DeviceCalibration.svelte
+++ b/src/ui/src/lib/DeviceCalibration.svelte
@@ -305,7 +305,7 @@
 	async function saveCalibration() {
 		if (!calculatedRefRssi) return;
 		try {
-			const response = await fetch(`${base}/api/device/${deviceSettings?.originalId}`, {
+			const response = await fetch(`${base}/api/device/${deviceSettings?.originalId || deviceSettings?.id}`, {
 				method: 'PUT',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ ...deviceSettings, 'rssi@1m': calculatedRefRssi })
@@ -313,6 +313,9 @@
 			if (response.ok) {
 				currentRefRssi = calculatedRefRssi;
 				toastStore.trigger({ message: 'Calibration saved successfully!' });
+			} else if (response.status === 400) {
+				const errorData = await response.json();
+				throw new Error(errorData.error || 'Bad request. Please check your input.');
 			} else {
 				throw new Error('Error saving calibration. Please try again.');
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clear, user-friendly error when attempting to save settings to an alias, with guidance to use the original device ID.
  * Save operations now return proper HTTP responses for more reliable feedback.

* **Bug Fixes**
  * Prevents saving calibration to alias IDs, avoiding inconsistent configurations.
  * UI gracefully handles 400 Bad Request with informative messaging and uses the device ID when the original ID is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->