### PR TITLE
Codex: publish bayesian room probabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Home Assistant Add-on / Docker container that solves indoor positions using MQ
 - Manages and configures ESPresense nodes
 - Updates node firmware
 - Adjusts device-specific settings
+- Publishes Bayesian room probabilities for fuzzy automations
 - Monitors and controls automatic node optimization
 
 ![image](https://user-images.githubusercontent.com/1491145/208942192-d8716e50-c822-48a7-a6d3-46b53ab9373e.png)
@@ -18,6 +19,42 @@ A Home Assistant Add-on / Docker container that solves indoor positions using MQ
 2. [Configuration Guide](https://espresense.com/companion/configuration)
 3. [Node Setup](https://espresense.com/companion/configuration#node-placement)
 4. [Optimization Guide](https://espresense.com/companion/optimization)
+
+## Bayesian probability output
+
+Enable the optional Bayesian publisher to expose per-room probability vectors alongside the traditional `device_tracker` state.
+Set `bayesian_probabilities.enabled: true` in `config.yaml` to turn it on:
+
+```yaml
+bayesian_probabilities:
+  enabled: true
+  discovery_threshold: 0.1   # auto-create sensors above this probability
+  retain: true               # keep MQTT state so HA restores after restart
+```
+
+When enabled the companion:
+
+- Publishes `espresense/companion/<device_id>/probabilities/<room>` topics containing a `0.0-1.0` float for each room.
+- Adds a `probabilities` object to the device attribute payload (`espresense/companion/<device_id>/attributes`).
+- Auto-discovers Home Assistant `sensor` entities for any room whose probability crosses the configured threshold.
+
+You can fuse multiple device probabilities into a person-level Bayesian sensor in Home Assistant:
+
+```yaml
+sensor:
+  - platform: bayesian
+    name: "Pat in Kitchen"
+    prior: 0.5
+    observations:
+      - platform: template
+        value_template: "{{ states('sensor.pat_phone_kitchen_probability') | float }}"
+        probability: 0.6
+      - platform: template
+        value_template: "{{ states('sensor.pat_watch_kitchen_probability') | float }}"
+        probability: 0.9
+```
+
+Automations can then trigger on thresholds (for example, turn on lights when `sensor.pat_in_kitchen > 0.7`).
 
 ## Need Help?
 - Join our [Discord Community](https://discord.gg/jbqmn7V6n6)

--- a/src/Models/AutoDiscovery.cs
+++ b/src/Models/AutoDiscovery.cs
@@ -119,6 +119,16 @@ public class AutoDiscovery
 
         [JsonProperty("status_topic")] public string? EntityStatusTopic { get; set; }
 
+        [JsonProperty("device_class")] public string? DeviceClass { get; set; }
+
+        [JsonProperty("state_class")] public string? StateClass { get; set; }
+
+        [JsonProperty("unit_of_measurement")] public string? UnitOfMeasurement { get; set; }
+
+        [JsonProperty("value_template")] public string? ValueTemplate { get; set; }
+
+        [JsonProperty("icon")] public string? Icon { get; set; }
+
         [JsonProperty("device")] public DeviceRecord? Device { get; set; }
 
         [JsonProperty("origin")] public OriginRecord? Origin { get; set; }

--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -24,7 +24,8 @@ namespace ESPresense.Models
                 ExcludeDevices = ExcludeDevices.Select(d => d.Clone()).ToArray(),
                 History = History.Clone(),
                 Locators = Locators.Clone(),
-                Optimization = Optimization.Clone()
+                Optimization = Optimization.Clone(),
+                BayesianProbabilities = BayesianProbabilities.Clone()
             };
         }
     }
@@ -112,6 +113,19 @@ namespace ESPresense.Models
                 IntervalSecs = IntervalSecs,
                 KeepSnapshotMins = KeepSnapshotMins,
                 Limits = new Dictionary<string, double>(Limits)
+            };
+        }
+    }
+
+    public partial class ConfigBayesianProbabilities
+    {
+        public ConfigBayesianProbabilities Clone()
+        {
+            return new ConfigBayesianProbabilities
+            {
+                Enabled = Enabled,
+                DiscoveryThreshold = DiscoveryThreshold,
+                Retain = Retain
             };
         }
     }

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -41,6 +41,9 @@ namespace ESPresense.Models
         [YamlMember(Alias = "history")]
         public ConfigHistory History { get; set; } = new();
 
+        [YamlMember(Alias = "bayesian_probabilities")]
+        public ConfigBayesianProbabilities BayesianProbabilities { get; set; } = new();
+
         [YamlMember(Alias = "bounds")]
         public double[][] Bounds { get; set; } = [];
 
@@ -141,6 +144,18 @@ namespace ESPresense.Models
 
         [YamlIgnore] public double CorrelationWeight => Weights.TryGetValue("correlation", out var val) ? val : 0.5;
         [YamlIgnore] public double RmseWeight => Weights.TryGetValue("rmse", out var val) ? val : 0.5;
+    }
+
+    public partial class ConfigBayesianProbabilities
+    {
+        [YamlMember(Alias = "enabled")]
+        public bool Enabled { get; set; } = false;
+
+        [YamlMember(Alias = "discovery_threshold")]
+        public double DiscoveryThreshold { get; set; } = 0.1;
+
+        [YamlMember(Alias = "retain")]
+        public bool Retain { get; set; } = true;
     }
 
     public partial class ConfigHistory

--- a/src/Services/DeviceTracker.cs
+++ b/src/Services/DeviceTracker.cs
@@ -243,6 +243,7 @@ public class DeviceTracker(State state, IMqttCoordinator mqtt, TelemetryService 
                 Log.Information("[-] Track {Device}", device);
                 foreach (var ad in device.HassAutoDiscovery)
                     await ad.Delete(mqtt);
+                device.ResetBayesianState();
             }
             return true;
         }

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -50,6 +50,11 @@ optimization:
     rmse: 0.5
 
 
+bayesian_probabilities:
+  enabled: false          # Publish per-room probability vectors (default disabled)
+  discovery_threshold: 0.1 # Minimum probability before creating Home Assistant sensor
+  retain: true             # Retain MQTT probability topics so sensors restore on restart
+
 locators:
   nadaraya_watson:
     enabled: true

--- a/tests/MultiScenarioLocatorTests.cs
+++ b/tests/MultiScenarioLocatorTests.cs
@@ -1,12 +1,13 @@
-using ESPresense.Models;
+using ESPresense.Controllers;
 using ESPresense.Locators;
+using ESPresense.Models;
 using ESPresense.Services;
 using ESPresense.Utils;
-using ESPresense.Controllers;
+using MathNet.Spatial.Euclidean;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Newtonsoft.Json.Linq;
 using SQLite;
-using MathNet.Spatial.Euclidean;
 
 namespace ESPresense.Companion.Tests;
 
@@ -17,10 +18,25 @@ public class MultiScenarioLocatorTests
         public bool Locate(Scenario scenario) => true;
     }
 
+    private class FixedRoomLocator(Room room, int confidence) : ILocate
+    {
+        private readonly Room _room = room;
+        private readonly int _confidence = confidence;
+
+        public bool Locate(Scenario scenario)
+        {
+            scenario.Room = _room;
+            scenario.Floor = _room.Floor;
+            scenario.Confidence = _confidence;
+            scenario.Fixes = (scenario.Fixes ?? 0) + 1;
+            scenario.UpdateLocation(new Point3D());
+            return true;
+        }
+    }
+
     [Test]
     public async Task NotHomeStateWhenAllScenariosExpire()
     {
-        // Arrange minimal environment
         var workDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg");
         Directory.CreateDirectory(workDir);
 
@@ -53,15 +69,100 @@ public class MultiScenarioLocatorTests
         device.Scenarios.Add(scenario);
 
         mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}", "not_home", false))
-                .Returns(Task.CompletedTask)
-                .Verifiable();
+            .Returns(Task.CompletedTask)
+            .Verifiable();
 
-        // Act
         await locator.ProcessDevice(device);
 
-        // Assert
         Assert.That(device.ReportedState, Is.EqualTo("not_home"));
         mqttMock.Verify();
+    }
+
+    [Test]
+    public async Task BayesianProbabilitiesPublishedWhenEnabled()
+    {
+        var workDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, Guid.NewGuid().ToString());
+        Directory.CreateDirectory(workDir);
+
+        var configPath = Path.Combine(workDir, "config.yaml");
+        await File.WriteAllTextAsync(configPath,
+            """
+            mqtt:
+              host:
+            timeout: 30
+            bayesian_probabilities:
+              enabled: true
+              discovery_threshold: 0.1
+              retain: true
+            locators:
+              nadaraya_watson:
+                enabled: false
+              nelder_mead:
+                enabled: false
+              nearest_node:
+                enabled: false
+            floors:
+              - id: f1
+                name: Floor 1
+                bounds: [[0,0,0],[5,5,3]]
+                rooms:
+                  - name: Kitchen
+                    points: [[0,0],[0,1],[1,1],[1,0]]
+                  - name: Hall
+                    points: [[1,0],[1,1],[2,1],[2,0]]
+            nodes: []
+            devices: []
+            """);
+
+        var configLoader = new ConfigLoader(workDir);
+        await configLoader.ConfigAsync();
+        var supervisor = new SupervisorConfigLoader(NullLogger<SupervisorConfigLoader>.Instance);
+
+        var mqttMock = new Mock<MqttCoordinator>(configLoader,
+            NullLogger<MqttCoordinator>.Instance,
+            new MqttNetLogger(),
+            supervisor);
+
+        var published = new List<(string topic, string? payload, bool retain)>();
+        mqttMock
+            .Setup(m => m.EnqueueAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()))
+            .Returns<string, string?, bool>((topic, payload, retain) =>
+            {
+                published.Add((topic, payload, retain));
+                return Task.CompletedTask;
+            });
+
+        var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object));
+        var tele = new TelemetryService(mqttMock.Object);
+        var deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
+        var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
+        var leaseServiceMock = new Mock<ILeaseService>();
+        var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history, leaseServiceMock.Object);
+
+        var config = await configLoader.ConfigAsync();
+        var floor = state.Floors.Values.First();
+        var rooms = floor.Rooms.Values.ToArray();
+        var kitchen = rooms.First(r => r.Name == "Kitchen");
+        var hall = rooms.First(r => r.Name == "Hall");
+
+        var device = new Device("device1", null, TimeSpan.FromSeconds(30)) { Name = "Device" };
+        device.Scenarios.Add(new Scenario(config, new FixedRoomLocator(kitchen, 80), kitchen.Name));
+        device.Scenarios.Add(new Scenario(config, new FixedRoomLocator(hall, 60), hall.Name));
+
+        await locator.ProcessDevice(device);
+
+        var probabilityTopic = $"espresense/companion/{device.Id}/probabilities/kitchen";
+        Assert.That(published.Any(p => p.topic == probabilityTopic && !string.IsNullOrWhiteSpace(p.payload)), Is.True);
+
+        var attributesMessage = published.LastOrDefault(p => p.topic == $"espresense/companion/{device.Id}/attributes");
+        Assert.That(attributesMessage.payload, Is.Not.Null);
+
+        var attributes = JObject.Parse(attributesMessage.payload!);
+        var probabilities = attributes["probabilities"] as JObject;
+        Assert.That(probabilities, Is.Not.Null);
+        Assert.That(probabilities!["Kitchen"]?.Value<double>(), Is.GreaterThan(0));
+        Assert.That(probabilities!["Hall"]?.Value<double>(), Is.GreaterThan(0));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add a bayesian_probabilities config section and publish per-room probability vectors alongside the existing tracker state
- expose retained MQTT topics plus Home Assistant discovery sensors for high-confidence rooms and document how to consume them
- extend DeviceTracker and locator pipeline with probability smoothing helpers and a unit test covering the new payloads

## Testing
- dotnet test *(fails: dotnet is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d00873dd8c8324bde1d937e7cd16f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Publish per-room Bayesian probabilities over MQTT (normalized) with optional Home Assistant sensor auto-discovery; per-device probability topics and person-level fusion examples included.
  - New configuration: bayesian_probabilities.enabled, discovery_threshold, retain.

- Documentation
  - README: overview, MQTT topics/payloads, discovery behavior, YAML examples, and automation usage.

- Improvements
  - Discovery metadata extended with sensor metadata (device class, state class, unit, value template, icon).
  - Probability lifecycle: create/remove discovery sensors based on threshold; device probability/state reset when untracked.

- Tests
  - Added test verifying probabilities are published when enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->