### PR TITLE
fix: update accordion usage after skeleton upgrade

### DIFF
--- a/src/ui/src/lib/NodeCalibrationMatrix.svelte
+++ b/src/ui/src/lib/NodeCalibrationMatrix.svelte
@@ -103,84 +103,81 @@
 	<div class="w-full px-4 py-2">
 		<!-- Active Optimizers -->
 		{#if $calibration?.optimizerState?.optimizers}
-		<div class="mb-4">
-			<span class="text-sm font-semibold text-surface-600-400">Active Optimizers:</span>
-			<span class="text-surface-900-100 ml-2">{$calibration.optimizerState.optimizers}</span>
-		</div>
+			<div class="mb-4">
+				<span class="text-sm font-semibold text-surface-600-400">Active Optimizers:</span>
+				<span class="text-surface-900-100 ml-2">{$calibration.optimizerState.optimizers}</span>
+			</div>
 		{/if}
 
 		<!-- Calibration Statistics -->
 		{#if $calibration?.optimizerState}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-			<div class="card p-4 preset-tonal">
-				<div class="text-2xl font-bold text-primary-500">{$calibration?.rmse?.toFixed(3) ?? 'n/a'}</div>
-				<div class="text-sm text-surface-600-400">RMSE</div>
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+				<div class="card p-4 preset-tonal">
+					<div class="text-2xl font-bold text-primary-500">{$calibration?.rmse?.toFixed(3) ?? 'n/a'}</div>
+					<div class="text-sm text-surface-600-400">RMSE</div>
+				</div>
+				<div class="card p-4 preset-tonal">
+					<div class="text-2xl font-bold text-primary-500">{$calibration?.r?.toFixed(3) ?? 'n/a'}</div>
+					<div class="text-sm text-surface-600-400">R</div>
+				</div>
+				<div class="card p-4 preset-tonal">
+					<div class="text-2xl font-bold text-success-500">{$calibration?.optimizerState?.bestRMSE?.toFixed(3) ?? 'n/a'}</div>
+					<div class="text-sm text-surface-600-400">Best RMSE</div>
+				</div>
+				<div class="card p-4 preset-tonal">
+					<div class="text-2xl font-bold text-success-500">{$calibration?.optimizerState?.bestR?.toFixed(3) ?? 'n/a'}</div>
+					<div class="text-sm text-surface-600-400">Best R</div>
+				</div>
 			</div>
-			<div class="card p-4 preset-tonal">
-				<div class="text-2xl font-bold text-primary-500">{$calibration?.r?.toFixed(3) ?? 'n/a'}</div>
-				<div class="text-sm text-surface-600-400">R</div>
-			</div>
-			<div class="card p-4 preset-tonal">
-				<div class="text-2xl font-bold text-success-500">{$calibration?.optimizerState?.bestRMSE?.toFixed(3) ?? 'n/a'}</div>
-				<div class="text-sm text-surface-600-400">Best RMSE</div>
-			</div>
-			<div class="card p-4 preset-tonal">
-				<div class="text-2xl font-bold text-success-500">{$calibration?.optimizerState?.bestR?.toFixed(3) ?? 'n/a'}</div>
-				<div class="text-sm text-surface-600-400">Best R</div>
-			</div>
-		</div>
 		{/if}
 
 		{#if $calibration?.matrix}
-		<div class="card">
-			<header class="text-lg font-semibold mb-4">Node Calibration</header>
-			<div class="space-y-4">
-				<div class="flex flex-col gap-6 rounded-lg border border-surface-300-700 bg-surface-50-950 p-4 shadow-sm">
-					<div class="flex flex-wrap items-center justify-between gap-3">
-						<div class="flex flex-wrap items-center gap-2">
-							<button class="btn {data_point === 0 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 0)}>Error %</button>
-							<button class="btn {data_point === 1 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 1)}>Error (m)</button>
-							<button class="btn {data_point === 2 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 2)}>Absorption</button>
-							<button class="btn {data_point === 3 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 3)}>Rx Rssi Adj</button>
-							<button class="btn {data_point === 4 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 4)}>Tx Rssi Ref</button>
-							<button class="btn {data_point === 5 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 5)}>Variance (m)</button>
+			<div class="card">
+				<header class="text-lg font-semibold mb-4">Node Calibration</header>
+				<div class="space-y-4">
+					<div class="flex flex-col gap-6 rounded-lg border border-surface-300-700 bg-surface-50-950 p-4 shadow-sm">
+						<div class="flex flex-wrap items-center justify-between gap-3">
+							<div class="flex flex-wrap items-center gap-2">
+								<button class="btn {data_point === 0 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 0)}>Error %</button>
+								<button class="btn {data_point === 1 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 1)}>Error (m)</button>
+								<button class="btn {data_point === 2 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 2)}>Absorption</button>
+								<button class="btn {data_point === 3 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 3)}>Rx Rssi Adj</button>
+								<button class="btn {data_point === 4 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 4)}>Tx Rssi Ref</button>
+								<button class="btn {data_point === 5 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 5)}>Variance (m)</button>
+							</div>
+							<button class="btn preset-filled-warning-500" onclick={resetCalibration}> Reset Calibration </button>
 						</div>
-						<button class="btn preset-filled-warning-500" onclick={resetCalibration}> Reset Calibration </button>
 					</div>
-				</div>
-				<div class="overflow-x-auto">
-					<table class="table">
-						<thead>
-							<tr>
-								<th style="text-align: center; color: oklch(1 0 none);">Name</th>
-								{#each rxColumns as id}
-									<th class="h-32 whitespace-nowrap px-2 py-1 min-w-10" style="position: relative;">
-										<div style="writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg); position: absolute; bottom: 8px; left: 50%; transform-origin: center; transform: translateX(-50%) rotate(180deg); white-space: nowrap; color: oklch(1 0 none);">Rx: {id}</div>
-									</th>
-								{/each}
-							</tr>
-						</thead>
-						<tbody>
-							{#each Object.entries($calibration.matrix) as [id1, n1] (id1)}
+					<div class="overflow-x-auto">
+						<table class="table">
+							<thead>
 								<tr>
-									<td style="text-align: right; white-space: nowrap;">Tx: {id1}</td>
-									{#each rxColumns as id2 (id2)}
-										<td style="text-align: center; {coloring(n1[id2]?.percent)}" use:tooltip={n1[id2] ? `Map Distance ${Number(n1[id2].mapDistance?.toPrecision(3))} - Measured ${Number(n1[id2]?.distance?.toPrecision(3))} = Error ${Number(n1[id2]?.diff?.toPrecision(3))}` : 'No beacon Received in last 30 seconds'}
-											>{#if n1[id2]}{value(n1[id2], data_point)}{/if}</td
-										>
+									<th style="text-align: center; color: oklch(1 0 none);">Name</th>
+									{#each rxColumns as id}
+										<th class="h-32 whitespace-nowrap px-2 py-1 min-w-10" style="position: relative;">
+											<div style="writing-mode: vertical-rl; text-orientation: mixed; transform: rotate(180deg); position: absolute; bottom: 8px; left: 50%; transform-origin: center; transform: translateX(-50%) rotate(180deg); white-space: nowrap; color: oklch(1 0 none);">Rx: {id}</div>
+										</th>
 									{/each}
 								</tr>
-							{/each}
-						</tbody>
-					</table>
+							</thead>
+							<tbody>
+								{#each Object.entries($calibration.matrix) as [id1, n1] (id1)}
+									<tr>
+										<td style="text-align: right; white-space: nowrap;">Tx: {id1}</td>
+										{#each rxColumns as id2 (id2)}
+											<td style="text-align: center; {coloring(n1[id2]?.percent)}" use:tooltip={n1[id2] ? `Map Distance ${Number(n1[id2].mapDistance?.toPrecision(3))} - Measured ${Number(n1[id2]?.distance?.toPrecision(3))} = Error ${Number(n1[id2]?.diff?.toPrecision(3))}` : 'No beacon Received in last 30 seconds'}
+												>{#if n1[id2]}{value(n1[id2], data_point)}{/if}</td
+											>
+										{/each}
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
 				</div>
 			</div>
-		</div>
 		{:else}
-		<div class="text-center py-8 text-surface-600-400">
-			Loading calibration data...
-		</div>
+			<div class="text-center py-8 text-surface-600-400">Loading calibration data...</div>
 		{/if}
 	</div>
 </div>
-

--- a/src/ui/src/lib/modals/Firmware.svelte
+++ b/src/ui/src/lib/modals/Firmware.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-        import { Progress as SkeletonProgress } from '@skeletonlabs/skeleton-svelte';
+	import { Progress as SkeletonProgress } from '@skeletonlabs/skeleton-svelte';
 	import { firmwareTypes, cpuNames, getFirmwareUrl, firmwareUpdate } from '$lib/firmware';
 	import type { Node } from '$lib/types';
 	import { getToastStore } from '$lib/toast/toastStore';
@@ -96,11 +96,11 @@
 		{#each log as item}
 			<p>{item}</p>
 		{/each}
-                <SkeletonProgress value={percentComplete} max={100}>
-                        <SkeletonProgress.Track class="w-full">
-                                <SkeletonProgress.Range />
-                        </SkeletonProgress.Track>
-                </SkeletonProgress>
+		<SkeletonProgress value={percentComplete} max={100}>
+			<SkeletonProgress.Track class="w-full">
+				<SkeletonProgress.Range />
+			</SkeletonProgress.Track>
+		</SkeletonProgress>
 		{#if progress > Progress.Updating}
 			<footer class="modal-footer {parent.regionFooter}">
 				{#if progress == Progress.Success}

--- a/src/ui/src/routes/calibration/devices/[id]/+page.svelte
+++ b/src/ui/src/routes/calibration/devices/[id]/+page.svelte
@@ -13,8 +13,6 @@
 	let { data = {} }: { data: { settings?: DeviceSetting } } = $props();
 	let device = $derived($devices?.find((d) => d.id === data.settings?.id));
 
-	let accordionValue = $state(['details']);
-
 	const deviceDetails = readable<DeviceDetailItem[]>([], (set) => {
 		const deviceId = data.settings?.id;
 		if (!deviceId) return () => {};


### PR DESCRIPTION
## Summary
- switch the device, calibration, and node detail accordions to use the new `defaultValue` API instead of a controlled value
- drop the unused local accordion state now that the components manage their own expansion state

## Testing
- pnpm -C src/ui exec prettier --check src/routes/devices/[id]/+page.svelte src/routes/calibration/devices/[id]/+page.svelte src/routes/nodes/[id]/+page.svelte
- pnpm -C src/ui build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ac6a8b9883249aa6510fc168d9e7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive migration guide from v3 to v4 with automated migration flow and component remapping.

* **Refactor**
  * Updated component layouts and structures for improved consistency across accordions, progress indicators, and data tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->