### PR TITLE
docs: update README Docker pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPresense-companion
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/ESPresense/ESPresense-companion)
-![Docker Pulls](https://badgen.net/docker/pulls/espresense/espresense-companion)
+![Docker Pulls](https://img.shields.io/docker/pulls/espresense/espresense-companion)
 
 A Home Assistant Add-on / Docker container that solves indoor positions using MQTT data received from multiple ESPresense nodes. The companion is the central brain of your ESPresense system. It:
 - Processes distance readings from all nodes using trilateration to determine device locations


### PR DESCRIPTION
## Summary
- replace the README Docker pulls badge to use shields.io because badgen.net is unavailable

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a6731e248324ae9222bb0173aca5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker pulls badge image source in documentation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->