### PR TITLE
Align pnpm store with cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -24,6 +29,9 @@ jobs:
       with:
         version: 10
         run_install: false
+
+    - name: Configure pnpm store path
+      run: pnpm config set store-dir ~/.pnpm-store
 
     - name: Setup pnpm cache
       uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- configure pnpm to use the cached store directory in CI to match the cache path

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694093c711f483249c5add48f5052dc2)