### PR TITLE
fix: NearestNode locator now assigns room instead of null

### DIFF
--- a/src/Locators/NearestNode.cs
+++ b/src/Locators/NearestNode.cs
@@ -34,8 +34,10 @@ internal class NearestNode : ILocate
         scenario.Confidence = 1;
         scenario.Fixes = 1;
 
-        // Find the floor containing the node
-        scenario.Floor = node.Floors?.FirstOrDefault();
+        // Find the floor containing the node's location; fall back to first configured floor
+        scenario.Floor = node.Floors == null
+            ? null
+            : SpatialUtils.FindFloorContaining(location, node.Floors) ?? node.Floors.FirstOrDefault();
 
         // Try to find the room:
         // 1. First try to find a room containing the node's location


### PR DESCRIPTION
## Summary

- NearestNode previously always set `scenario.Room = null`, causing devices to appear in a fake "NearestNode" room
- Now finds the actual room by:
  1. First trying to find a room containing the node's location via polygon check
  2. Falling back to matching node ID/name to room names (case-insensitive)

This ensures devices using the NearestNode fallback locator report actual room names instead of "NearestNode".

## Test plan

- [ ] Device with only 1 node in range should report the node's room, not "NearestNode"
- [ ] Device with multiple nodes should still use trilateration (NearestNode is fallback only)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fallback location detection with intelligent room and floor determination using the nearest active node
  * Fallback location fixes now properly marked with low confidence values to distinguish them from primary fixes
  * Improved room identification with multiple fallback strategies when primary matching fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->