### PR TITLE
feat: add release dispatch workflow

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,22 @@
+name: Dispatch Events
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.ESPRESENSE_CONTENTS_TOKEN }}
+          repository: ESPresense/ESPresense.com
+          event-type: new-release
+          client-payload: >
+            {
+              "repository": "ESPresense/ESPresense-companion",
+              "ref": "${{ github.ref }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
### Motivation
- Dispatch a repository event to `ESPresense/ESPresense.com` when a release is published so the website can react to new companion releases.

### Description
- Add `.github/workflows/release-dispatch.yml` which triggers on `release` `published` and runs `peter-evans/repository-dispatch@v4` using `secrets.ESPRESENSE_CONTENTS_TOKEN` to send a `new-release` event with `repository`, `ref`, and `sha` in the `client-payload`.

### Testing
- No automated tests were run because this is a CI workflow change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b7a5fb3c83248fa67628b355be44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to improve notification workflow when new releases are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->