### PR TITLE
feat: add PR labeler Action and include common branch prefixes

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,27 @@
+feature:
+  - 'feature/*'
+  - 'feat/*'
+fix:
+  - 'fix/*'
+chore:
+  - 'chore/*'
+docs:
+  - 'docs/*'
+ci:
+  - 'ci/*'
+build:
+  - 'build/*'
+deps:
+  - 'deps/*'
+  - 'dependabot/*'
+  - 'bump/*'
+refactor:
+  - 'refactor/*'
+test:
+  - 'test/*'
+major:
+  - 'major/*'
+minor:
+  - 'minor/*'
+patch:
+  - 'patch/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml


### PR DESCRIPTION
### Motivation
- Automatically apply labels to pull requests based on branch-name patterns and ensure common repository branch prefixes like `build/*`, `deps/*`, `dependabot/*`, and `bump/*` are recognized for correct categorization and release tooling.

### Description
- Add ` .github/workflows/pr-labeler.yml` to run `TimonVS/pr-labeler-action@v5` on `pull_request` events with appropriate `contents: read` and `pull-requests: write` permissions, and add ` .github/pr-labeler.yml` containing mappings for `feature/*`/`feat/*`, `fix/*`, `chore/*`, `docs/*`, `ci/*`, `build/*`, `deps/*` (including `dependabot/*` and `bump/*`), `refactor/*`, `test/*`, and `major/*`/`minor/*`/`patch/*`.

### Testing
- No automated tests were run because this is a CI configuration change and validation will occur when the workflow executes on GitHub (open/reopen/synchronize a PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c5bdcb6c8324bedb56219f75d583)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated pull request labeling based on branch naming conventions to streamline PR organization and workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->