### PR TITLE
feat: directional antenna gain model for auto-optimization

### DIFF
--- a/src/Controllers/FirmwareController.cs
+++ b/src/Controllers/FirmwareController.cs
@@ -14,22 +14,14 @@ public class FirmwareController : Controller
     private readonly FirmwareTypeStore _firmwareTypeStore;
     private readonly NodeSettingsStore _nodeSettingsStore;
     private readonly NodeTelemetryStore _nts;
-    private readonly FirmwareUpdateJobService _firmwareUpdateJobs;
     private readonly ILogger<FirmwareController> _logger;
     private readonly HttpClient _hc;
 
-    public FirmwareController(
-        FirmwareTypeStore firmwareTypeStore,
-        NodeSettingsStore nodeSettingsStore,
-        NodeTelemetryStore nts,
-        FirmwareUpdateJobService firmwareUpdateJobs,
-        ILogger<FirmwareController> logger,
-        HttpClient hc)
+    public FirmwareController(FirmwareTypeStore firmwareTypeStore, NodeSettingsStore nodeSettingsStore, NodeTelemetryStore nts, ILogger<FirmwareController> logger, HttpClient hc)
     {
         _firmwareTypeStore = firmwareTypeStore;
         _nodeSettingsStore = nodeSettingsStore;
         _nts = nts;
-        _firmwareUpdateJobs = firmwareUpdateJobs;
         _logger = logger;
         _hc = hc;
     }
@@ -45,7 +37,8 @@ public class FirmwareController : Controller
     [Route("api/firmware/download")]
     public async Task<IActionResult> DownloadFirmware([FromQuery] string url)
     {
-        if (!_firmwareUpdateJobs.IsTrustedFirmwareUrl(url))
+        if (!url.StartsWith("https://github.com/ESPresense/") &&
+            !url.StartsWith("https://nightly.link/ESPresense/"))
         {
             _logger.LogWarning("Attempted to download firmware from untrusted URL: {url}", url.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
             return StatusCode(StatusCodes.Status400BadRequest, "Only ESPresense GitHub URLs are allowed");
@@ -73,11 +66,6 @@ public class FirmwareController : Controller
     public async Task Update(string id, [FromQuery] string url)
     {
         if (!HttpContext.WebSockets.IsWebSocketRequest)
-        {
-            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return;
-        }
-        if (!_firmwareUpdateJobs.IsTrustedFirmwareUrl(url))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
             return;
@@ -135,7 +123,7 @@ public class FirmwareController : Controller
         if (!isZip && mediaType != "application/zip")
             return ms1;
 
-        using (var zipArchive = new ZipArchive(ms1, ZipArchiveMode.Read, leaveOpen: true))
+        using (var zipArchive = new ZipArchive(ms1))
         {
             foreach (var entry in zipArchive.Entries)
             {
@@ -143,7 +131,6 @@ public class FirmwareController : Controller
                 await using var entryStream = entry.Open();
                 await entryStream.CopyToAsync(ms2);
                 ms2.Position = 0;
-                ms1.Dispose();
                 return ms2;
             }
         }

--- a/src/Controllers/NodeController.cs
+++ b/src/Controllers/NodeController.cs
@@ -7,11 +7,7 @@ namespace ESPresense.Controllers;
 
 [Route("api/node")]
 [ApiController]
-public class NodeController(
-    NodeSettingsStore nodeSettingsStore,
-    NodeTelemetryStore nodeTelemetryStore,
-    State state,
-    FirmwareUpdateJobService firmwareUpdateJobs) : ControllerBase
+public class NodeController(NodeSettingsStore nodeSettingsStore, NodeTelemetryStore nodeTelemetryStore, State state) : ControllerBase
 {
     /// <summary>
     /// Retrieve the saved settings for a node and any runtime details available from in-memory state.
@@ -40,13 +36,9 @@ public class NodeController(
     }
 
     [HttpPost("{id}/update")]
-    public async Task<IActionResult> Update(string id, [FromBody] NodeUpdate? ds = null)
+    public async Task Update(string id, [FromBody] NodeUpdate? ds = null)
     {
-        if (!firmwareUpdateJobs.IsValidNodeUpdateUrl(ds?.Url))
-            return BadRequest("Only ESPresense GitHub URLs are allowed");
-
         await nodeSettingsStore.Update(id, ds?.Url);
-        return NoContent();
     }
 
     [HttpPost("{id}/restart")]

--- a/src/Controllers/StateController.cs
+++ b/src/Controllers/StateController.cs
@@ -8,7 +8,6 @@ using ESPresense.Extensions;
 using ESPresense.Utils;
 using ESPresense.Models;
 using ESPresense.Services;
-using Serilog;
 using AutoMapper;
 using Microsoft.AspNetCore.Mvc;
 using Nito.AsyncEx;
@@ -132,6 +131,8 @@ public class StateController : ControllerBase
                 if (txNs.Calibration.TxRefRssi is not null) rxM["tx_ref_rssi"] = txNs.Calibration.TxRefRssi.Value;
                 if (rxNs.Calibration.RxAdjRssi is not null) rxM["rx_adj_rssi"] = rxNs.Calibration.RxAdjRssi.Value;
                 if (rxNs.Calibration.Absorption is not null) rxM["absorption"] = rxNs.Calibration.Absorption.Value;
+                if (rxNs.Calibration.Azimuth is not null) rxM["azimuth"] = rxNs.Calibration.Azimuth.Value;
+                if (rxNs.Calibration.Elevation is not null) rxM["elevation"] = rxNs.Calibration.Elevation.Value;
                 rxM["mapDistance"] = rx.MapDistance;
                 rxM["distance"] = rx.Distance;
                 rxM["rssi"] = rx.Rssi;
@@ -163,6 +164,8 @@ public class StateController : ControllerBase
                 // Anchored devices don't have tx calibration settings, but receivers still have their settings
                 if (rxNs.Calibration.RxAdjRssi is not null) rxM["rx_adj_rssi"] = rxNs.Calibration.RxAdjRssi.Value;
                 if (rxNs.Calibration.Absorption is not null) rxM["absorption"] = rxNs.Calibration.Absorption.Value;
+                if (rxNs.Calibration.Azimuth is not null) rxM["azimuth"] = rxNs.Calibration.Azimuth.Value;
+                if (rxNs.Calibration.Elevation is not null) rxM["elevation"] = rxNs.Calibration.Elevation.Value;
 
                 // Calculate map distance from anchor to receiver
                 var mapDistance = device.Anchor!.Location.DistanceTo(rxNode.Location);
@@ -183,6 +186,22 @@ public class StateController : ControllerBase
 
         c.R = MathUtils.CalculatePearsonCorrelation(mapDistances, actualDistances);
         c.RMSE = MathUtils.CalculateRMSE(mapDistances, actualDistances);
+
+        // Populate per-node calibration summary (antenna, azimuth, elevation, etc.)
+        foreach (var (nodeId, node) in _state.Nodes)
+        {
+            var ns = _nsd.Get(nodeId);
+            c.Nodes[node.Name ?? nodeId] = new NodeCalibrationSummary
+            {
+                Antenna = node.AntennaProfile,
+                Azimuth = ns.Calibration.Azimuth,
+                Elevation = ns.Calibration.Elevation,
+                Absorption = ns.Calibration.Absorption,
+                RxAdjRssi = ns.Calibration.RxAdjRssi,
+                TxRefRssi = ns.Calibration.TxRefRssi,
+            };
+        }
+
         return c;
     }
 
@@ -376,9 +395,11 @@ public class StateController : ControllerBase
             foreach (var node in _state.Nodes.Values)
             {
                 var nodeSettings = _nsd.Get(node.Id);
-                nodeSettings.Calibration.TxRefRssi = 0;
-                nodeSettings.Calibration.RxAdjRssi = 0;
-                nodeSettings.Calibration.Absorption = 0;
+                nodeSettings.Calibration.TxRefRssi = null;
+                nodeSettings.Calibration.RxAdjRssi = null;
+                nodeSettings.Calibration.Absorption = null;
+                nodeSettings.Calibration.Azimuth = null;
+                nodeSettings.Calibration.Elevation = null;
                 await _nsd.Set(node.Id, nodeSettings);
             }
 
@@ -388,32 +409,6 @@ public class StateController : ControllerBase
         {
             _logger.LogError(ex, "Error resetting calibration");
             return StatusCode(500, new { error = "An error occurred while resetting calibration" });
-        }
-    }
-
-    [HttpGet("api/state/calibration/auto-optimize")]
-    public IActionResult GetAutoOptimize()
-    {
-        var c = _config.Config;
-        return Ok(new { autoOptimize = c?.Optimization.Enabled ?? false });
-    }
-
-    [HttpPost("api/state/calibration/auto-optimize")]
-    public async Task<IActionResult> ToggleAutoOptimize([FromBody] bool enable)
-    {
-        try
-        {
-            var c = _config.Config;
-            if (c == null) return StatusCode(500, new { error = "Config not loaded" });
-
-            c.Optimization.Enabled = enable;
-            await _config.SaveSectionAsync("optimization", c.Optimization);
-            return Ok(new { autoOptimize = enable });
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Failed to save auto-optimize setting");
-            return StatusCode(500, new { error = "Failed to save auto-optimize setting" });
         }
     }
 }

--- a/src/Locators/BaseMultilateralizer.cs
+++ b/src/Locators/BaseMultilateralizer.cs
@@ -1,5 +1,6 @@
 using ESPresense.Extensions;
 using ESPresense.Models;
+using ESPresense.Services;
 using ESPresense.Utils;
 using MathNet.Spatial.Euclidean;
 using Serilog;
@@ -14,15 +15,192 @@ public abstract class BaseMultilateralizer : ILocate
     protected readonly Device Device;
     protected readonly Floor Floor;
     protected readonly State State;
+    protected readonly NodeSettingsStore NodeSettings;
+    protected readonly DeviceSettingsStore DeviceSettings;
 
-    protected BaseMultilateralizer(Device device, Floor floor, State state)
+    protected BaseMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings)
     {
         Device = device;
         Floor = floor;
         State = state;
+        NodeSettings = nodeSettings;
+        DeviceSettings = deviceSettings;
     }
 
-    public abstract bool Locate(Scenario scenario);
+    /// <summary>
+    /// Solves for the device position given valid nodes and an initial guess.
+    /// Returns null to indicate a soft failure (template will fall back to using the guess with confidence=1).
+    /// Implementations may update scenario fields such as Error, Fixes, Iterations, ReasonForExit, and Scale.
+    /// </summary>
+    protected abstract Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess);
+
+    /// <summary>
+    /// Template method: initialises scenario, calls <see cref="Solve"/> in a 3-iteration
+    /// gain-correction loop, then finalises confidence and room assignment.
+    /// </summary>
+    public bool Locate(Scenario scenario)
+    {
+        if (!InitializeScenario(scenario, out var nodes, out var guess))
+            return false;
+
+        int confidence = scenario.Confidence ?? 0;
+        var enriched = false;
+        try
+        {
+            if (nodes.Length < 3 || Floor.Bounds == null || Floor.Bounds.Length < 2)
+            {
+                confidence = 1;
+                scenario.UpdateLocation(guess);
+            }
+            else
+            {
+                // Enrich nodes with calibration data before iterative solve
+                EnrichNodes(nodes);
+                enriched = true;
+
+                Point3D? result = null;
+                for (int iteration = 0; iteration < 3; iteration++)
+                {
+                    // On iterations 1+, compute cos(θ) for gain correction
+                    if (iteration > 0 && result.HasValue)
+                        UpdateNodeCosTheta(nodes, result.Value);
+
+                    result = Solve(scenario, nodes, guess);
+                    if (result == null)
+                    {
+                        confidence = 1;
+                        scenario.UpdateLocation(guess);
+                        return FinalizeScenario(scenario, confidence);
+                    }
+                }
+
+                scenario.UpdateLocation(result!.Value);
+                CalculateAndSetPearsonCorrelation(scenario, nodes);
+
+                int nodesPossibleOnline = State.Nodes.Values
+                    .Count(n => n.Floors?.Contains(Floor) ?? false);
+
+                confidence = MathUtils.CalculateConfidence(
+                    scenario.Error,
+                    scenario.PearsonCorrelation,
+                    nodes.Length,
+                    nodesPossibleOnline
+                );
+            }
+        }
+        catch (Exception ex)
+        {
+            confidence = HandleLocatorException(ex, scenario, guess);
+        }
+        finally
+        {
+            if (enriched)
+                ResetEnrichment(nodes);
+        }
+
+        return FinalizeScenario(scenario, confidence);
+    }
+
+    private void EnrichNodes(DeviceToNode[] nodes)
+    {
+        foreach (var dn in nodes)
+        {
+            // Only activate RSSI-based distance recomputation when real RSSI data is present.
+            // Tests and legacy call sites that set Distance directly (without ReadMessage) have Rssi==0;
+            // real BLE measurements always have a non-zero RSSI (typically -40 to -100 dBm).
+            if (dn.Rssi == 0.0) continue;
+
+            var nodeId = dn.Node?.Id;
+            var ns = nodeId != null ? NodeSettings.Get(nodeId) : null;
+            var deviceId = dn.Device?.Id;
+            var ds = deviceId != null ? DeviceSettings.Get(deviceId) : null;
+
+            dn.NodeAbsorption = ns?.Calibration?.Absorption ?? 3.0;
+            dn.NodeRxAdjRssi = ns?.Calibration?.RxAdjRssi ?? 0;
+
+            // Resolve antenna profile from config (profile name → built-in → null).
+            // Null means no antenna configured → NodeGMaxDb stays null
+            // → CorrectedDistance returns null → Distance falls back to firmware (backward-compatible).
+            var configNode = State.Config?.Nodes?.FirstOrDefault(n => n.GetId() == nodeId);
+            var antenna = State.Config?.ResolveAntenna(configNode?.Antenna);
+            dn.NodeGMaxDb = null;
+            dn.NodePatternExponent = 0;
+            dn.NodeBackLossDb = 0;
+            if (antenna != null)
+            {
+                dn.NodeGMaxDb = antenna.GMaxDb;
+                dn.NodePatternExponent = antenna.PatternExponent;
+                dn.NodeBackLossDb = antenna.BackLoss;
+                // Use calibrated angles if available, otherwise default to 0°/0° (horizontal, forward)
+                double azDeg = ns?.Calibration?.Azimuth ?? 0.0;
+                double elDeg = ns?.Calibration?.Elevation ?? 0.0;
+                dn.NodeAzimuthRad = azDeg * Math.PI / 180.0;
+                dn.NodeElevationRad = elDeg * Math.PI / 180.0;
+            }
+            else
+            {
+                dn.NodeAzimuthRad = null;
+                dn.NodeElevationRad = null;
+            }
+
+            // TxAdjRssi: device transmit adjustment from DeviceSettingsStore
+            dn.TxAdjRssi = ds?.RefRssi ?? 0;
+        }
+    }
+
+    private static void UpdateNodeCosTheta(DeviceToNode[] nodes, Point3D devicePos)
+    {
+        foreach (var dn in nodes)
+        {
+            if (dn.NodeAzimuthRad is null || dn.NodeElevationRad is null)
+            {
+                dn.NodeCosTheta = null;
+                continue;
+            }
+
+            double azRad = dn.NodeAzimuthRad.Value;
+            double elRad = dn.NodeElevationRad.Value;
+
+            // Pointing vector: Px=sin(az)*cos(el), Py=cos(az)*cos(el), Pz=sin(el)
+            double px = Math.Sin(azRad) * Math.Cos(elRad);
+            double py = Math.Cos(azRad) * Math.Cos(elRad);
+            double pz = Math.Sin(elRad);
+
+            // Vector from node to device
+            if (dn.Node?.HasLocation != true)
+            {
+                dn.NodeCosTheta = null;
+                continue;
+            }
+            var nodePos = dn.Node.Location;
+            double dx = devicePos.X - nodePos.X;
+            double dy = devicePos.Y - nodePos.Y;
+            double dz = devicePos.Z - nodePos.Z;
+            double len = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+
+            if (len < 1e-9)
+                dn.NodeCosTheta = 1.0; // co-located → θ=0°, max gain
+            else
+            {
+                // Raw signed cosθ: sign determines front vs back hemisphere in CorrectedDistance
+                double cosTheta = (px * dx + py * dy + pz * dz) / len;
+                dn.NodeCosTheta = cosTheta;
+            }
+        }
+    }
+
+    private static void ResetEnrichment(DeviceToNode[] nodes)
+    {
+        foreach (var dn in nodes)
+        {
+            dn.NodeGMaxDb = null;
+            dn.NodeCosTheta = null;
+            dn.NodeAzimuthRad = null;
+            dn.NodeElevationRad = null;
+            dn.NodePatternExponent = 0;
+            dn.NodeBackLossDb = 0;
+        }
+    }
 
     /// <summary>
     /// Initializes scenario with valid nodes and performs initial validation
@@ -34,6 +212,13 @@ public abstract class BaseMultilateralizer : ILocate
 
         nodes = Device.Nodes.Values
             .Where(a => a.Current && (a.Node?.Floors?.Contains(Floor) ?? false))
+            .Where(a =>
+            {
+                if (Floor.Bounds == null || Floor.Bounds.Length < 2) return true;
+                var z = a.Node?.Location.Z;
+                if (!z.HasValue) return false;
+                return z.Value >= Floor.Bounds[0].Z && z <= Floor.Bounds[1].Z;
+            })
             .OrderBy(a => a.Distance)
             .ToArray();
 

--- a/src/Locators/BfgsMultilateralizer.cs
+++ b/src/Locators/BfgsMultilateralizer.cs
@@ -1,6 +1,7 @@
 ﻿using ESPresense.Utils;
 using ESPresense.Extensions;
 using ESPresense.Models;
+using ESPresense.Services;
 using ESPresense.Weighting;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization;
@@ -13,106 +14,72 @@ public class BfgsMultilateralizer : BaseMultilateralizer
 {
     private readonly IWeighting _weighting;
 
-    public BfgsMultilateralizer(Device device, Floor floor, State state)
-        : base(device, floor, state)
+    public BfgsMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings)
+        : base(device, floor, state, nodeSettings, deviceSettings)
     {
         // Load weighting from BFGS config, defaulting to Gaussian if not specified
         _weighting = WeightingFactory.Create(state.Config?.Locators?.Bfgs?.Weighting);
     }
 
-    public override bool Locate(Scenario scenario)
+    protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
     {
         double Weight(int index, int total) => _weighting.Get(index, total);
         double Error(IList<double> x, DeviceToNode dn) => new Point3D(x[0], x[1], x[2]).DistanceTo(dn.Node!.Location) - dn.Distance;
 
-        if (!InitializeScenario(scenario, out var nodes, out var guess))
-            return false;
+        double weightSum = Enumerable.Range(0, nodes.Length)
+            .Select(i => Weight(i, nodes.Length))
+            .Sum();
+        if (weightSum <= 0) weightSum = 1;
 
-        int confidence = scenario.Confidence ?? 0;
-        try
-        {
-            if (nodes.Length < 3 || Floor.Bounds == null || Floor.Bounds.Length < 2)
+        var lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds![0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z });
+        var upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z });
+        var obj = ObjectiveFunction.Gradient(
+            x => nodes
+                .Select((dn, i) => new { err = Error(x, dn), weight = Weight(i, nodes.Length) })
+                .Sum(a => a.weight * Math.Pow(a.err, 2)) / weightSum
+            ,
+            x =>
             {
-                confidence = 1;
-                scenario.UpdateLocation(guess);
-            }
-            else
-            {
-                double weightSum = Enumerable.Range(0, nodes.Length)
-                    .Select(i => Weight(i, nodes.Length))
-                    .Sum();
-                if (weightSum <= 0) weightSum = 1;
+                var current = new Point3D(x[0], x[1], x[2]);
+                var gradient = new double[3];
 
-                var lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z });
-                var upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z });
-                var obj = ObjectiveFunction.Gradient(
-                    x => nodes
-                        .Select((dn, i) => new { err = Error(x, dn), weight = Weight(i, nodes.Length) })
-                        .Sum(a => a.weight * Math.Pow(a.err, 2)) / weightSum
-                    ,
-                    x =>
+                for (var i = 0; i < 3; i++)
+                {
+                    gradient[i] = nodes.Select((dn, j) =>
                     {
-                        var current = new Point3D(x[0], x[1], x[2]);
-                        var gradient = new double[3];
+                        var nodeLoc = dn.Node!.Location;
+                        var dist = current.DistanceTo(nodeLoc);
+                        if (dist < 1e-6) dist = 1e-6; // Avoid division by zero
 
-                        for (var i = 0; i < 3; i++)
-                        {
-                            gradient[i] = nodes.Select((dn, j) =>
-                            {
-                                var nodeLoc = dn.Node!.Location;
-                                var dist = current.DistanceTo(nodeLoc);
-                                if (dist < 1e-6) dist = 1e-6; // Avoid division by zero
+                        var err = dist - dn.Distance;
+                        var dDist_dX = (x[i] - nodeLoc.ToVector()[i]) / dist;
 
-                                var err = dist - dn.Distance;
-                                var dDist_dX = (x[i] - nodeLoc.ToVector()[i]) / dist;
+                        return 2 * err * dDist_dX * Weight(j, nodes.Length);
+                    }).Sum() / weightSum;
+                }
+                return Vector<double>.Build.Dense(gradient);
+            });
 
-                                return 2 * err * dDist_dX * Weight(j, nodes.Length);
-                            }).Sum() / weightSum;
-                        }
-                        return Vector<double>.Build.Dense(gradient);
-                    });
-
-                var clampedGuess = ClampToFloorBounds(guess);
-                var initialGuess = Vector<double>.Build.DenseOfArray(new[]
-                {
-                    clampedGuess.X,
-                    clampedGuess.Y,
-                    clampedGuess.Z
-                });
-                var solver = new BfgsBMinimizer(1e-5, 1e-5, 1e-5, 1000);
-                var result = solver.FindMinimum(obj, lowerBound, upperBound, initialGuess);
-                scenario.UpdateLocation(new Point3D(result.MinimizingPoint[0], result.MinimizingPoint[1], result.MinimizingPoint[2]));
-                scenario.Fixes = nodes.Length;
-                scenario.Error = result.FunctionInfoAtMinimum.Value;
-                scenario.Iterations = result switch
-                {
-                    MinimizationWithLineSearchResult mwl =>
-                        mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
-                    _ => result.Iterations
-                };
-
-                scenario.ReasonForExit = result.ReasonForExit;
-
-                CalculateAndSetPearsonCorrelation(scenario, nodes);
-
-                // Calculate number of possible nodes for this floor
-                int nodesPossibleOnline = State.Nodes.Values
-                    .Count(n => n.Floors?.Contains(Floor) ?? false);
-
-                // Use the centralized confidence calculation
-                confidence = MathUtils.CalculateConfidence(
-                    scenario.Error,
-                    scenario.PearsonCorrelation,
-                    nodes.Length,
-                    nodesPossibleOnline
-                );
-            }
-        }
-        catch (Exception ex)
+        var clampedGuess = ClampToFloorBounds(guess);
+        var initialGuess = Vector<double>.Build.DenseOfArray(new[]
         {
-            confidence = HandleLocatorException(ex, scenario, guess);
-        }
+            clampedGuess.X,
+            clampedGuess.Y,
+            clampedGuess.Z
+        });
+        var solver = new BfgsBMinimizer(1e-5, 1e-5, 1e-5, 1000);
+        var result = solver.FindMinimum(obj, lowerBound, upperBound, initialGuess);
 
-        return FinalizeScenario(scenario, confidence);
+        scenario.Fixes = nodes.Length;
+        scenario.Error = result.FunctionInfoAtMinimum.Value;
+        scenario.Iterations = result switch
+        {
+            MinimizationWithLineSearchResult mwl =>
+                mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
+            _ => result.Iterations
+        };
+        scenario.ReasonForExit = result.ReasonForExit;
+
+        return new Point3D(result.MinimizingPoint[0], result.MinimizingPoint[1], result.MinimizingPoint[2]);
     }
 }

--- a/src/Locators/GaussNewtonMultilateralizer.cs
+++ b/src/Locators/GaussNewtonMultilateralizer.cs
@@ -2,6 +2,7 @@
 using ESPresense.Utils;
 using ESPresense.Extensions;
 using ESPresense.Models;
+using ESPresense.Services;
 using MathNet.Numerics.LinearAlgebra.Double;
 using MathNet.Numerics.Optimization;
 using MathNet.Spatial.Euclidean;
@@ -11,81 +12,55 @@ namespace ESPresense.Locators;
 
 public class GaussNewtonMultilateralizer : BaseMultilateralizer
 {
-    public GaussNewtonMultilateralizer(Device device, Floor floor, State state)
-        : base(device, floor, state)
+    public GaussNewtonMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings)
+        : base(device, floor, state, nodeSettings, deviceSettings)
     {
     }
 
-    public override bool Locate(Scenario scenario)
+    protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
     {
         double Error(Point3D pos1, Point3D pos2, double dist) => pos1.DistanceTo(pos2) - dist;
-
-        if (!InitializeScenario(scenario, out var nodes, out var guess))
-            return false;
 
         var (pos, ranges) = SelectNonColinearTransmitters(nodes, 4);
 
         if (pos.Length <= 1)
-        {
-            ResetScenario(scenario);
-            return false;
-        }
+            return null; // Not enough non-colinear nodes; base template falls back to guess
 
         scenario.Minimum = ranges.Min(a => a);
         scenario.Fixes = pos.Length;
 
-        int confidence = scenario.Confidence ?? 0;
+        if (pos.Length < 3)
+            return null; // Not enough non-colinear nodes for 3-D solve; use guess
+
+        // Floor.Bounds non-null is guaranteed by the base template before calling Solve()
+        var lowerBound = new Vector3((float)Floor.Bounds![0].X, (float)Floor.Bounds[0].Y, (float)Floor.Bounds[0].Z);
+        var upperBound = new Vector3((float)Floor.Bounds[1].X, (float)Floor.Bounds[1].Y, (float)Floor.Bounds[1].Z);
+        var clampedGuess = ClampToFloorBounds(guess);
+        var initialGuess = new Vector3((float)clampedGuess.X, (float)clampedGuess.Y, (float)clampedGuess.Z);
+
         try
         {
-            if (pos.Length < 3 || Floor.Bounds == null || Floor.Bounds.Length < 2)
+            var gaussNewton = new GaussNewton(pos, ranges, lowerBound, upperBound);
+            var result = gaussNewton.FindPosition(initialGuess);
+
+            scenario.Fixes = pos.Length;
+            scenario.Error = pos.Select((p, i) => Math.Pow(Error(result.ToPoint3D(), p.ToPoint3D(), ranges[i]), 2)).Average();
+            scenario.Iterations = gaussNewton.Iterations;
+            if (!gaussNewton.Converged)
             {
-                confidence = 1;
-                scenario.UpdateLocation(guess);
+                scenario.ReasonForExit = ExitCondition.ExceedIterations;
+                return null;
             }
-            else
-            {
-                var lowerBound = new Vector3((float)Floor.Bounds[0].X, (float)Floor.Bounds[0].Y, (float)Floor.Bounds[0].Z);
-                var upperBound = new Vector3((float)Floor.Bounds[1].X, (float)Floor.Bounds[1].Y, (float)Floor.Bounds[1].Z);
-                var clampedGuess = ClampToFloorBounds(guess);
-                var initialGuess = new Vector3((float)clampedGuess.X, (float)clampedGuess.Y, (float)clampedGuess.Z);
 
-                var gaussNewton = new GaussNewton(pos, ranges, lowerBound, upperBound);
-                var result = gaussNewton.FindPosition(initialGuess);
+            scenario.ReasonForExit = ExitCondition.Converged;
 
-                scenario.UpdateLocation(new Point3D(result.X, result.Y, result.Z));
-                scenario.Fixes = pos.Length;
-                scenario.Error = pos.Select((p, i) => Math.Pow(Error(result.ToPoint3D(), p.ToPoint3D(), ranges[i]), 2)).Average();
-                scenario.Iterations = gaussNewton.Iterations;
-
-                scenario.ReasonForExit = ExitCondition.Converged;
-            }
+            return new Point3D(result.X, result.Y, result.Z);
         }
         catch (MaximumIterationsException)
         {
             scenario.ReasonForExit = ExitCondition.ExceedIterations;
-            confidence = 1;
-            scenario.UpdateLocation(guess);
+            return null; // Base template falls back to using guess with confidence=1
         }
-        catch (Exception ex)
-        {
-            confidence = HandleLocatorException(ex, scenario, guess);
-        }
-
-        CalculateAndSetPearsonCorrelation(scenario, nodes);
-
-        // Calculate number of possible nodes for this floor
-        int nodesPossibleOnline = State.Nodes.Values
-            .Count(n => n.Floors?.Contains(Floor) ?? false);
-
-        // Use the centralized confidence calculation
-        confidence = MathUtils.CalculateConfidence(
-            scenario.Error,
-            scenario.PearsonCorrelation,
-            nodes.Length,
-            nodesPossibleOnline
-        );
-
-        return FinalizeScenario(scenario, confidence);
     }
 
     private Tuple<Vector3[], float[]> SelectNonColinearTransmitters(DeviceToNode[] dns, int numberOfTransmitters = 4)
@@ -153,6 +128,8 @@ public class GaussNewtonMultilateralizer : BaseMultilateralizer
         }
 
         public int? Iterations { get; set; }
+        public int MaxIterations { get; } = 100;
+        public bool Converged { get; private set; }
 
         private double Error(Vector3 x, Vector3 dnLocation, float dnDistance)
         {
@@ -163,9 +140,13 @@ public class GaussNewtonMultilateralizer : BaseMultilateralizer
         {
             var guess = initialGuess;
             var lambda = 1e-3; // Regularization parameter
+            Converged = false;
+            Iterations = 0;
 
-            for (var iter = 0; iter < 100; ++iter)
+            for (var iter = 0; iter < MaxIterations; ++iter)
             {
+                Iterations = iter + 1;
+
                 // Construct the Jacobian matrix
                 var jacobian = DenseMatrix.OfArray(new double[_transmitters.Length, 3]);
                 for (var i = 0; i < _transmitters.Length; ++i)
@@ -187,7 +168,11 @@ public class GaussNewtonMultilateralizer : BaseMultilateralizer
                 guess = Vector3.Max(_lowerBounds, Vector3.Min(_upperBounds, guess));
 
                 // If the step size is small enough, stop iterating
-                if (step.L2Norm() < 1e-5) break;
+                if (step.L2Norm() < 1e-5)
+                {
+                    Converged = true;
+                    break;
+                }
             }
 
             return guess;

--- a/src/Locators/MLEMultilateralizer.cs
+++ b/src/Locators/MLEMultilateralizer.cs
@@ -1,6 +1,7 @@
 ﻿using ESPresense.Utils;
 using ESPresense.Extensions;
 using ESPresense.Models;
+using ESPresense.Services;
 using ESPresense.Weighting;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization;
@@ -13,13 +14,13 @@ public class MLEMultilateralizer : BaseMultilateralizer
 {
     private readonly IWeighting _weighting;
 
-    public MLEMultilateralizer(Device device, Floor floor, State state) : base(device, floor, state)
+    public MLEMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings) : base(device, floor, state, nodeSettings, deviceSettings)
     {
         // Load weighting from MLE config, defaulting to Gaussian if not specified
         _weighting = WeightingFactory.Create(state.Config?.Locators?.Mle?.Weighting);
     }
 
-    public override bool Locate(Scenario scenario)
+    protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
     {
         double Error(IList<double> x, DeviceToNode dn)
         {
@@ -34,91 +35,68 @@ public class MLEMultilateralizer : BaseMultilateralizer
             return error * error / (2 * variance);
         }
 
-        if (!InitializeScenario(scenario, out var nodes, out var guess))
-            return false;
+        var weights = nodes.Select((dn, i) => _weighting.Get(i, nodes.Length)).ToArray();
+        var weightSum = weights.Sum();
+        if (weightSum <= 0) weightSum = 1;
 
-        int confidence = scenario.Confidence ?? 0;
+        Vector<double>? lowerBound = null;
+        Vector<double>? upperBound = null;
+        if (Floor.Bounds != null && Floor.Bounds.Length >= 2)
+        {
+            lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z, 0.5 });
+            upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z, 1.5 });
+        }
+        var obj = ObjectiveFunction.Value(
+            x =>
+            {
+                var distanceFromBoundingBox = lowerBound == null || upperBound == null
+                    ? 0
+                    : lowerBound.Subtract(x)
+                        .PointwiseMaximum(x.Subtract(upperBound))
+                        .PointwiseMaximum(0)
+                        .L2Norm();
+                return (distanceFromBoundingBox > 0 ? Math.Pow(5, 1 + distanceFromBoundingBox) : 0) + Math.Pow(5 * (1 - x[3]), 2) + nodes
+                    .Select((dn, i) => new { err = Error(x, dn), weight = weights[i] })
+                    .Sum(a => a.weight * a.err) / weightSum;
+            });
+
+        var clampedGuess = ClampToFloorBounds(guess);
+        var initialGuess = Vector<double>.Build.DenseOfArray(new[]
+        {
+            clampedGuess.X,
+            clampedGuess.Y,
+            clampedGuess.Z,
+            scenario.Scale ?? 1.0
+        });
+        double xDelta = Floor.Bounds == null ? 0.1 : Math.Max((Floor.Bounds[1].X - Floor.Bounds[0].X) * 0.05, 0.1);
+        double yDelta = Floor.Bounds == null ? 0.1 : Math.Max((Floor.Bounds[1].Y - Floor.Bounds[0].Y) * 0.05, 0.1);
+        double zDelta = Floor.Bounds == null ? 0.1 : Math.Max((Floor.Bounds[1].Z - Floor.Bounds[0].Z) * 0.05, 0.1);
+        double scaleDelta = Math.Max(Math.Abs(initialGuess[3]) * 0.05, 0.05);
+        var initialPerturbation = Vector<double>.Build.DenseOfArray([xDelta, yDelta, zDelta, scaleDelta]);
+        var solver = new NelderMeadSimplex(1e-7, 10000);
+
         try
         {
-            if (nodes.Length < 3 || Floor.Bounds == null || Floor.Bounds.Length < 2)
+            var result = solver.FindMinimum(obj, initialGuess, initialPerturbation);
+            var minimizingPoint = lowerBound == null || upperBound == null
+                ? result.MinimizingPoint
+                : result.MinimizingPoint.PointwiseMinimum(upperBound).PointwiseMaximum(lowerBound);
+            scenario.Scale = minimizingPoint[3];
+            scenario.Fixes = nodes.Length;
+            scenario.Error = result.FunctionInfoAtMinimum.Value;
+            scenario.Iterations = result switch
             {
-                confidence = 1;
-                scenario.UpdateLocation(guess);
-            }
-            else
-            {
-                var weights = nodes.Select((dn, i) => _weighting.Get(i, nodes.Length)).ToArray();
-                var weightSum = weights.Sum();
-                if (weightSum <= 0) weightSum = 1;
-
-                var lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z, 0.5 });
-                var upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z, 1.5 });
-                var obj = ObjectiveFunction.Value(
-                    x =>
-                    {
-                        var distanceFromBoundingBox = lowerBound.Subtract(x)
-                            .PointwiseMaximum(x.Subtract(upperBound))
-                            .PointwiseMaximum(0)
-                            .L2Norm();
-                        return (distanceFromBoundingBox > 0 ? Math.Pow(5, 1 + distanceFromBoundingBox) : 0) + Math.Pow(5 * (1 - x[3]), 2) + nodes
-                            .Select((dn, i) => new { err = Error(x, dn), weight = weights[i] })
-                            .Sum(a => a.weight * a.err) / weightSum;
-                    });
-
-                var clampedGuess = ClampToFloorBounds(guess);
-                var initialGuess = Vector<double>.Build.DenseOfArray(new[]
-                {
-                    clampedGuess.X,
-                    clampedGuess.Y,
-                    clampedGuess.Z,
-                    scenario.Scale ?? 1.0
-                });
-                var centroid = Point3D.Centroid(nodes.Select(n => n.Node!.Location).Take(3)).ToVector();
-                var vectorToCentroid = centroid.Subtract(initialGuess.SubVector(0, 3)).Normalize(2);
-                var scaleDelta = 0.05 * initialGuess[3];
-                var initialPerturbation = Vector<double>.Build.DenseOfEnumerable(vectorToCentroid.Append(scaleDelta));
-                var solver = new NelderMeadSimplex(1e-7, 10000);
-                var result = solver.FindMinimum(obj, initialGuess, initialPerturbation);
-                var minimizingPoint = result.MinimizingPoint.PointwiseMinimum(upperBound).PointwiseMaximum(lowerBound);
-                scenario.UpdateLocation(new Point3D(minimizingPoint[0], minimizingPoint[1], minimizingPoint[2]));
-                scenario.Scale = minimizingPoint[3];
-                scenario.Fixes = nodes.Length;
-                scenario.Error = result.FunctionInfoAtMinimum.Value;
-                scenario.Iterations = result switch
-                {
-                    MinimizationWithLineSearchResult mwl =>
-                        mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
-                    _ => result.Iterations
-                };
-
-                scenario.ReasonForExit = result.ReasonForExit;
-
-                CalculateAndSetPearsonCorrelation(scenario, nodes);
-
-                // Calculate number of possible nodes for this floor
-                int nodesPossibleOnline = State.Nodes.Values
-                    .Count(n => n.Floors?.Contains(Floor) ?? false);
-
-                // Use the centralized confidence calculation
-                confidence = MathUtils.CalculateConfidence(
-                    scenario.Error,
-                    scenario.PearsonCorrelation,
-                    nodes.Length,
-                    nodesPossibleOnline
-                );
-            }
+                MinimizationWithLineSearchResult mwl =>
+                    mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
+                _ => result.Iterations
+            };
+            scenario.ReasonForExit = result.ReasonForExit;
+            return new Point3D(minimizingPoint[0], minimizingPoint[1], minimizingPoint[2]);
         }
         catch (MaximumIterationsException)
         {
             scenario.ReasonForExit = ExitCondition.ExceedIterations;
-            confidence = 1;
-            scenario.UpdateLocation(guess);
+            return null; // Base template will fall back to using guess with confidence=1
         }
-        catch (Exception ex)
-        {
-            confidence = HandleLocatorException(ex, scenario, guess);
-        }
-
-        return FinalizeScenario(scenario, confidence);
     }
 }

--- a/src/Locators/NelderMeadMultilateralizer.cs
+++ b/src/Locators/NelderMeadMultilateralizer.cs
@@ -1,6 +1,7 @@
 ﻿using ESPresense.Utils;
 using ESPresense.Extensions;
 using ESPresense.Models;
+using ESPresense.Services;
 using ESPresense.Weighting;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization;
@@ -13,101 +14,80 @@ public class NelderMeadMultilateralizer : BaseMultilateralizer
 {
     private readonly IWeighting _weighting;
 
-    public NelderMeadMultilateralizer(Device device, Floor floor, State state) : base(device, floor, state)
+    public NelderMeadMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings) : base(device, floor, state, nodeSettings, deviceSettings)
     {
         // Load weighting from NelderMead config, defaulting to Gaussian if not specified
         _weighting = WeightingFactory.Create(state.Config?.Locators?.NelderMead?.Weighting);
     }
 
-    public override bool Locate(Scenario scenario)
+    protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
     {
         double Error(IList<double> x, DeviceToNode dn) => new Point3D(x[0], x[1], x[2]).DistanceTo(dn.Node!.Location) * x[3] - dn.Distance;
 
-        if (!InitializeScenario(scenario, out var nodes, out var guess))
-            return false;
+        var weights = nodes.Select((dn, i) => _weighting.Get(i, nodes.Length)).ToArray();
+        var weightSum = weights.Sum();
+        if (weightSum <= 0) weightSum = 1;
 
-        int confidence = scenario.Confidence ?? 0;
+        Vector<double>? lowerBound = null;
+        Vector<double>? upperBound = null;
+        if (Floor.Bounds != null && Floor.Bounds.Length >= 2)
+        {
+            lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z, 0.5 });
+            upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z, 1.5 });
+        }
+        var obj = ObjectiveFunction.Value(
+            x =>
+            {
+                var distanceFromBoundingBox = lowerBound == null || upperBound == null
+                    ? 0
+                    : lowerBound.Subtract(x)
+                        .PointwiseMaximum(x.Subtract(upperBound))
+                        .PointwiseMaximum(0)
+                        .L2Norm();
+                return (distanceFromBoundingBox > 0 ? Math.Pow(5, 1 + distanceFromBoundingBox) : 0) + Math.Pow(5 * (1 - x[3]), 2) + nodes
+                    .Select((dn, i) => new { err = Error(x, dn), weight = weights[i] })
+                    .Sum(a => a.weight * Math.Pow(a.err, 2)) / weightSum;
+            });
+
+        var clampedGuess = ClampToFloorBounds(guess);
+        var initialGuess = Vector<double>.Build.DenseOfArray(new[]
+        {
+            clampedGuess.X,
+            clampedGuess.Y,
+            clampedGuess.Z,
+            scenario.Scale ?? 1.0
+        });
+        var centroid = Point3D.Centroid(nodes.Select(n => n.Node!.Location).Take(3)).ToVector();
+        var vectorToCentroid = centroid.Subtract(initialGuess.SubVector(0, 3));
+        vectorToCentroid = vectorToCentroid.L2Norm() < 1e-9
+            ? Vector<double>.Build.DenseOfArray([1.0, 0.0, 0.0])
+            : vectorToCentroid.Normalize(2);
+        var scaleDelta = 0.05 * initialGuess[3];
+        var initialPerturbation = Vector<double>.Build.DenseOfEnumerable(vectorToCentroid.Append(scaleDelta));
+        var solver = new NelderMeadSimplex(1e-7, 10000);
+
         try
         {
-            if (nodes.Length < 3 || Floor.Bounds == null || Floor.Bounds.Length < 2)
+            var result = solver.FindMinimum(obj, initialGuess, initialPerturbation);
+            var minimizingPoint = lowerBound == null || upperBound == null
+                ? result.MinimizingPoint
+                : result.MinimizingPoint.PointwiseMinimum(upperBound).PointwiseMaximum(lowerBound);
+            scenario.Scale = minimizingPoint[3];
+            scenario.Fixes = nodes.Length;
+            scenario.Error = result.FunctionInfoAtMinimum.Value;
+            scenario.Iterations = result switch
             {
-                confidence = 1;
-                scenario.UpdateLocation(guess);
-            }
-            else
-            {
-                var weights = nodes.Select((dn, i) => _weighting.Get(i, nodes.Length)).ToArray();
-                var weightSum = weights.Sum();
-                if (weightSum <= 0) weightSum = 1;
-
-                var lowerBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[0].X, Floor.Bounds[0].Y, Floor.Bounds[0].Z, 0.5 });
-                var upperBound = Vector<double>.Build.DenseOfArray(new[] { Floor.Bounds[1].X, Floor.Bounds[1].Y, Floor.Bounds[1].Z, 1.5 });
-                var obj = ObjectiveFunction.Value(
-                    x =>
-                    {
-                        var distanceFromBoundingBox = lowerBound.Subtract(x)
-                            .PointwiseMaximum(x.Subtract(upperBound))
-                            .PointwiseMaximum(0)
-                            .L2Norm();
-                        return (distanceFromBoundingBox > 0 ? Math.Pow(5, 1 + distanceFromBoundingBox) : 0) + Math.Pow(5 * (1 - x[3]), 2) + nodes
-                            .Select((dn, i) => new { err = Error(x, dn), weight = weights[i] })
-                            .Sum(a => a.weight * Math.Pow(a.err, 2)) / weightSum;
-                    });
-
-                var clampedGuess = ClampToFloorBounds(guess);
-                var initialGuess = Vector<double>.Build.DenseOfArray(new[]
-                {
-                    clampedGuess.X,
-                    clampedGuess.Y,
-                    clampedGuess.Z,
-                    scenario.Scale ?? 1.0
-                });
-                var centroid = Point3D.Centroid(nodes.Select(n => n.Node!.Location).Take(3)).ToVector();
-                var vectorToCentroid = centroid.Subtract(initialGuess.SubVector(0, 3)).Normalize(2);
-                var scaleDelta = 0.05 * initialGuess[3];
-                var initialPerturbation = Vector<double>.Build.DenseOfEnumerable(vectorToCentroid.Append(scaleDelta));
-                var solver = new NelderMeadSimplex(1e-7, 10000);
-                var result = solver.FindMinimum(obj, initialGuess, initialPerturbation);
-                var minimizingPoint = result.MinimizingPoint.PointwiseMinimum(upperBound).PointwiseMaximum(lowerBound);
-                scenario.UpdateLocation(new Point3D(minimizingPoint[0], minimizingPoint[1], minimizingPoint[2]));
-                scenario.Scale = minimizingPoint[3];
-                scenario.Fixes = nodes.Length;
-                scenario.Error = result.FunctionInfoAtMinimum.Value;
-                scenario.Iterations = result switch
-                {
-                    MinimizationWithLineSearchResult mwl =>
-                        mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
-                    _ => result.Iterations
-                };
-
-                scenario.ReasonForExit = result.ReasonForExit;
-
-                CalculateAndSetPearsonCorrelation(scenario, nodes);
-
-                // Calculate number of possible nodes for this floor
-                int nodesPossibleOnline = State.Nodes.Values
-                    .Count(n => n.Floors?.Contains(Floor) ?? false);
-
-                // Use the centralized confidence calculation
-                confidence = MathUtils.CalculateConfidence(
-                    scenario.Error,
-                    scenario.PearsonCorrelation,
-                    nodes.Length,
-                    nodesPossibleOnline
-                );
-            }
+                MinimizationWithLineSearchResult mwl =>
+                    mwl.IterationsWithNonTrivialLineSearch + mwl.TotalLineSearchIterations,
+                _ => result.Iterations
+            };
+            scenario.ReasonForExit = result.ReasonForExit;
+            return new Point3D(minimizingPoint[0], minimizingPoint[1], minimizingPoint[2]);
         }
         catch (MaximumIterationsException)
         {
             scenario.ReasonForExit = ExitCondition.ExceedIterations;
-            confidence = 1;
-            scenario.UpdateLocation(guess);
+            return null; // Base template will fall back to using guess with confidence=1
         }
-        catch (Exception ex)
-        {
-            confidence = HandleLocatorException(ex, scenario, guess);
-        }
-
-        return FinalizeScenario(scenario, confidence);
     }
 }

--- a/src/Models/Calibration.cs
+++ b/src/Models/Calibration.cs
@@ -5,6 +5,17 @@ public class Calibration
     public double? RMSE { get; set; }
     public double? R { get; set; }
     public Dictionary<string, Dictionary<string, Dictionary<string, double>>> Matrix { get; } = new();
+    public Dictionary<string, NodeCalibrationSummary> Nodes { get; } = new();
     public OptimizerState OptimizerState { get; set; } = new();
     public HashSet<string> Anchored { get; } = new();
+}
+
+public class NodeCalibrationSummary
+{
+    public string? Antenna { get; set; }
+    public double? Azimuth { get; set; }
+    public double? Elevation { get; set; }
+    public double? Absorption { get; set; }
+    public double? RxAdjRssi { get; set; }
+    public double? TxRefRssi { get; set; }
 }

--- a/src/Models/Config.Clone.cs
+++ b/src/Models/Config.Clone.cs
@@ -12,8 +12,8 @@ namespace ESPresense.Models
         {
             return new Config
             {
-                Mqtt = Mqtt?.Clone(),
-                Bounds = Bounds?.Select(b => b.ToArray()).ToArray(),
+                Mqtt = Mqtt?.Clone() ?? new ConfigMqtt(),
+                Bounds = Bounds?.Select(b => b.ToArray()).ToArray() ?? Array.Empty<double[]>(),
                 Timeout = Timeout,
                 AwayTimeout = AwayTimeout,
                 Gps = Gps.Clone(),
@@ -24,7 +24,8 @@ namespace ESPresense.Models
                 ExcludeDevices = ExcludeDevices.Select(d => d.Clone()).ToArray(),
                 History = History.Clone(),
                 Locators = Locators.Clone(),
-                Optimization = Optimization.Clone()
+                Optimization = Optimization.Clone(),
+                Antennas = Antennas?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone())
             };
         }
     }
@@ -264,7 +265,8 @@ namespace ESPresense.Models
                 Point = Point?.ToArray(),
                 Floors = Floors?.ToArray(),
                 Enabled = Enabled,
-                Stationary = Stationary
+                Stationary = Stationary,
+                Antenna = Antenna
             };
         }
     }

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -47,6 +47,9 @@ namespace ESPresense.Models
         [YamlMember(Alias = "floors")]
         public ConfigFloor[] Floors { get; set; } = Array.Empty<ConfigFloor>();
 
+        [YamlMember(Alias = "antennas")]
+        public Dictionary<string, ConfigAntenna>? Antennas { get; set; }
+
         [YamlMember(Alias = "nodes")]
         public ConfigNode[] Nodes { get; set; } = Array.Empty<ConfigNode>();
 
@@ -55,6 +58,25 @@ namespace ESPresense.Models
 
         [YamlMember(Alias = "exclude_devices")]
         public ConfigDevice[] ExcludeDevices { get; set; } = Array.Empty<ConfigDevice>();
+    }
+
+    public partial class Config
+    {
+        /// <summary>
+        /// Resolves an antenna profile by name (user antennas → built-ins).
+        /// Returns null when no antenna is configured (isotropic).
+        /// </summary>
+        public ConfigAntenna? ResolveAntenna(string? profileName)
+        {
+            if (profileName == null) return null;
+
+            if (Antennas != null && Antennas.TryGetValue(profileName, out var userAnt))
+                return userAnt;
+            if (ConfigAntenna.BuiltInAntennas.TryGetValue(profileName, out var builtIn))
+                return builtIn;
+
+            return null;
+        }
     }
 
     public partial class ConfigLocators
@@ -291,6 +313,29 @@ namespace ESPresense.Models
         public string GetId() => Id ?? Name?.ToSnakeCase()?.ToLower() ?? "none";
     }
 
+    public partial class ConfigAntenna
+    {
+        [YamlMember(Alias = "g_max_db")]
+        public double GMaxDb { get; set; }
+
+        [YamlMember(Alias = "pattern_exponent")]
+        public double PatternExponent { get; set; } = 2.0;
+
+        [YamlMember(Alias = "back_loss")]
+        public double BackLoss { get; set; } = 15.0;
+
+        public ConfigAntenna Clone() => (ConfigAntenna)MemberwiseClone();
+
+        public static readonly Dictionary<string, ConfigAntenna> BuiltInAntennas = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["pcb_ifa"] = new ConfigAntenna { GMaxDb = 3.4, PatternExponent = 0.28, BackLoss = 14.3 },
+            ["dev_board"] = new ConfigAntenna { GMaxDb = 2.5, PatternExponent = 0.25, BackLoss = 12 },
+            ["3d_pifa"] = new ConfigAntenna { GMaxDb = 2.0, PatternExponent = 0.03, BackLoss = 5.5 },
+            ["3d_pifa_pro"] = new ConfigAntenna { GMaxDb = 2.0, PatternExponent = 0.03, BackLoss = 5.5 },
+            ["external_dipole"] = new ConfigAntenna { GMaxDb = 4.0, PatternExponent = 0.2, BackLoss = 2 },
+        };
+    }
+
     public partial class ConfigNode
     {
         [YamlMember(Alias = "name")]
@@ -310,6 +355,9 @@ namespace ESPresense.Models
 
         [YamlMember(Alias = "stationary")]
         public bool Stationary { get; set; } = true;
+
+        [YamlMember(Alias = "antenna")]
+        public string? Antenna { get; set; }
 
         public string GetId() => Id ?? Name?.ToSnakeCase()?.ToLower() ?? "none";
     }

--- a/src/Models/DeviceToNode.cs
+++ b/src/Models/DeviceToNode.cs
@@ -19,6 +19,17 @@ public class DeviceToNode(Device device, Node node)
 
     public bool Current => DateTime.UtcNow - LastHit < Device!.Timeout;
 
+    // Antenna parameters populated by BaseMultilateralizer.EnrichNodeFields()
+    public double NodeAbsorption { get; set; }
+    public double NodeRxAdjRssi { get; set; }
+    public double? NodeGMaxDb { get; set; }
+    public double NodePatternExponent { get; set; }
+    public double NodeBackLossDb { get; set; }
+    public double? NodeAzimuthRad { get; set; }
+    public double? NodeElevationRad { get; set; }
+    public double? NodeCosTheta { get; set; }
+    public double TxAdjRssi { get; set; }
+
     public bool ReadMessage(DeviceMessage payload)
     {
         Rssi = payload.Rssi;

--- a/src/Models/Node.cs
+++ b/src/Models/Node.cs
@@ -24,6 +24,7 @@ public class Node(string id, NodeSourceType sourceType)
     public double? Z { get; private set; }
     public bool HasLocation => X.HasValue && Y.HasValue && Z.HasValue;
     public bool Stationary { get; private set; }
+    public string? AntennaProfile { get; private set; }
 
     [JsonConverter(typeof(NodeToNodeConverter))]
     public ConcurrentDictionary<string, NodeToNode> Nodes { get; } = new(comparer: StringComparer.OrdinalIgnoreCase);
@@ -59,6 +60,7 @@ public class Node(string id, NodeSourceType sourceType)
         Location = new Point3D(point?[0] ?? 0, point?[1] ?? 0, point?[2] ?? 0);
         Stationary = cn.Stationary;
         SourceType = NodeSourceType.Config;
+        AntennaProfile = cn.Antenna;
     }
 
     public Floor[]? Floors { get; private set; }

--- a/src/Models/NodeSettings.cs
+++ b/src/Models/NodeSettings.cs
@@ -95,5 +95,7 @@ public class CalibrationSettings
     public int? RxAdjRssi { get; set; }
     public double? Absorption { get; set; }
     public int? TxRefRssi { get; set; }
+    public double? Azimuth { get; set; }
+    public double? Elevation { get; set; }
     public CalibrationSettings Clone() => (CalibrationSettings)MemberwiseClone();
 }

--- a/src/Models/OptimizationResults.cs
+++ b/src/Models/OptimizationResults.cs
@@ -1,8 +1,6 @@
 using ESPresense.Services;
 using ESPresense.Utils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace ESPresense.Models;
 
@@ -32,10 +30,39 @@ public class OptimizationResults
                 double mapDistance = m.Rx.Location.DistanceTo(m.Tx.Location);
 
                 double rxAdjRssi = rxPv?.RxAdjRssi ?? rx.Calibration.RxAdjRssi ?? 0;
-                double txRefRssi = txPv?.TxRefRssi ?? tx.Calibration.TxRefRssi ?? -59;
+                double txRefRssi = txPv?.TxRefRssi ?? tx.Calibration.TxRefRssi ?? m.RefRssi;
                 double pathLossExponent = rxPv?.Absorption ?? rx.Calibration.Absorption ?? 2.7;
 
-                double predictedRssi = txRefRssi - 10 * pathLossExponent * Math.Log10(mapDistance);
+                // Apply antenna gain correction for both Rx and Tx directional antennas.
+                // For node-to-node paths, both antennas affect the signal.
+                double gainDb = 0.0;
+                double dx = m.Tx.Location.X - m.Rx.Location.X;
+                double dy = m.Tx.Location.Y - m.Rx.Location.Y;
+                double dz = m.Tx.Location.Z - m.Rx.Location.Z;
+                if (m.Rx.HasDirectionalAntenna)
+                {
+                    double azRad = (rxPv?.Azimuth ?? rx.Calibration.Azimuth ?? 0.0) * Math.PI / 180.0;
+                    double elRad = (rxPv?.Elevation ?? rx.Calibration.Elevation ?? 0.0) * Math.PI / 180.0;
+                    double px = Math.Sin(azRad) * Math.Cos(elRad);
+                    double py = Math.Cos(azRad) * Math.Cos(elRad);
+                    double pz = Math.Sin(elRad);
+                    gainDb += MathUtils.ComputeGainDb(px, py, pz, dx, dy, dz,
+                        10.0 * Math.Log10(m.Rx.GMax), m.Rx.PatternExponent, m.Rx.BackLossDb);
+                }
+                if (m.Tx.HasDirectionalAntenna)
+                {
+                    Nodes.TryGetValue(m.Tx.Id, out var txPvLocal);
+                    double azRad = (txPvLocal?.Azimuth ?? tx.Calibration.Azimuth ?? 0.0) * Math.PI / 180.0;
+                    double elRad = (txPvLocal?.Elevation ?? tx.Calibration.Elevation ?? 0.0) * Math.PI / 180.0;
+                    double px = Math.Sin(azRad) * Math.Cos(elRad);
+                    double py = Math.Cos(azRad) * Math.Cos(elRad);
+                    double pz = Math.Sin(elRad);
+                    // Tx→Rx: direction vector is negated (Rx - Tx)
+                    gainDb += MathUtils.ComputeGainDb(px, py, pz, -dx, -dy, -dz,
+                        10.0 * Math.Log10(m.Tx.GMax), m.Tx.PatternExponent, m.Tx.BackLossDb);
+                }
+
+                double predictedRssi = txRefRssi + gainDb - 10 * pathLossExponent * Math.Log10(mapDistance);
                 double measuredRssi = m.GetAdjustedRssi(rxAdjRssi);
 
                 predictedValues.Add(predictedRssi);

--- a/src/Models/OptimizationSnapshot.cs
+++ b/src/Models/OptimizationSnapshot.cs
@@ -35,6 +35,13 @@ public class OptNode
     public string Id { get; set; }
     public string? Name { get; set; }
     public Point3D Location { get; set; }
+    public bool IsNode { get; set; }
+    public bool HasDirectionalAntenna { get; set; }
+    public double GMax { get; set; } = 1.0;
+    public double PatternExponent { get; set; } = 2.0;
+    public double BackLossDb { get; set; } = 15.0;
+    public double AzimuthRad { get; set; }
+    public double ElevationRad { get; set; }
 }
 
 public class Measure

--- a/src/Models/ProposedValues.cs
+++ b/src/Models/ProposedValues.cs
@@ -6,4 +6,6 @@ public class ProposedValues
     public double? TxRefRssi { get; set; }
     public double? Absorption { get; set; }
     public double? Error { get; set; }
+    public double? Azimuth { get; set; }
+    public double? Elevation { get; set; }
 }

--- a/src/Models/State.cs
+++ b/src/Models/State.cs
@@ -13,6 +13,8 @@ namespace ESPresense.Models;
 public class State
 {
     private readonly NodeTelemetryStore _nts;
+    private readonly NodeSettingsStore _nss;
+    private readonly Lazy<DeviceSettingsStore> _dss;
 
     /// <summary>
     /// Initializes a new State, wiring telemetry and configuration handling.
@@ -22,9 +24,11 @@ public class State
     /// Loading the configuration populates Floors, Nodes, device tracking structures (by literal and pattern globs),
     /// selects the locators' weighting strategy, and marks existing Devices for checking.
     /// </remarks>
-    public State(ConfigLoader cl, NodeTelemetryStore nts)
+    public State(ConfigLoader cl, NodeTelemetryStore nts, NodeSettingsStore nss, Lazy<DeviceSettingsStore> dss)
     {
         _nts = nts;
+        _nss = nss;
+        _dss = dss;
         void LoadConfig(Config c)
         {
             Config = c;
@@ -164,6 +168,21 @@ public class State
             }
         }
 
+        // Mark ESPresense infrastructure nodes and populate antenna parameters
+        foreach (var (nodeId, infraNode) in Nodes)
+        {
+            if (!nodes.TryGetValue(nodeId, out var optNode)) continue;
+            optNode.IsNode = true;
+            var antenna = Config?.ResolveAntenna(infraNode.AntennaProfile);
+            if (antenna != null)
+            {
+                optNode.HasDirectionalAntenna = true;
+                optNode.GMax = Math.Pow(10.0, antenna.GMaxDb / 10.0);
+                optNode.PatternExponent = antenna.PatternExponent;
+                optNode.BackLossDb = antenna.BackLoss;
+            }
+        }
+
         // Remove expired snapshots by time
         var expiryMinutes = Config?.Optimization?.KeepSnapshotMins ?? 5;
         var expiryThreshold = DateTime.UtcNow.AddMinutes(-expiryMinutes);
@@ -211,15 +230,15 @@ public class State
         {
             if (nelderMead?.Enabled ?? false)
                 foreach (var floor in GetFloorsByIds(nelderMead?.Floors))
-                    yield return new Scenario(Config, new NelderMeadMultilateralizer(device, floor, this), floor.Name);
+                    yield return new Scenario(Config, new NelderMeadMultilateralizer(device, floor, this, _nss, _dss.Value), floor.Name);
 
             if (bfgs?.Enabled ?? false)
                 foreach (var floor in GetFloorsByIds(bfgs?.Floors))
-                    yield return new Scenario(Config, new BfgsMultilateralizer(device, floor, this), floor.Name);
+                    yield return new Scenario(Config, new BfgsMultilateralizer(device, floor, this, _nss, _dss.Value), floor.Name);
 
             if (mle?.Enabled ?? false)
                 foreach (var floor in GetFloorsByIds(mle?.Floors))
-                    yield return new Scenario(Config, new MLEMultilateralizer(device, floor, this), floor.Name);
+                    yield return new Scenario(Config, new MLEMultilateralizer(device, floor, this, _nss, _dss.Value), floor.Name);
 
             if (multiFloor?.Enabled ?? false)
                 yield return new Scenario(Config, new MultiFloorMultilateralizer(device, this), "MultiFloor");
@@ -237,7 +256,7 @@ public class State
             if (Floors.Values.Any())
             {
                 foreach (var floor in Floors.Values)
-                    yield return new Scenario(Config, new NelderMeadMultilateralizer(device, floor, this), floor.Name);
+                    yield return new Scenario(Config, new NelderMeadMultilateralizer(device, floor, this, _nss, _dss.Value), floor.Name);
             }
             else
             {

--- a/src/Optimizers/CombinedOptimizer.cs
+++ b/src/Optimizers/CombinedOptimizer.cs
@@ -1,12 +1,19 @@
 using ESPresense.Models;
+using ESPresense.Utils;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization;
 using Serilog;
+
+// Type aliases for per-node azimuth/elevation collections (semantic clarity for 3-tuple returns)
+using NodeAbsorptionMap = System.Collections.Generic.Dictionary<string, double>;
+using NodeAzimuthMap = System.Collections.Generic.Dictionary<string, double>;
+using NodeElevationMap = System.Collections.Generic.Dictionary<string, double>;
 
 namespace ESPresense.Optimizers;
 
 public class CombinedOptimizer : IOptimizer
 {
+    private const double BaseTxRefRssi = -59.0;
     private readonly State _state;
 
     public CombinedOptimizer(State state)
@@ -29,12 +36,12 @@ public class CombinedOptimizer : IOptimizer
         try
         {
             if (optimization == null) return results;
-            
-            // Step 1: Optimize RxAdjRssi and path-specific absorptions
-            var (rxAdjRssiDict, pathAbsorptionDict, error) = OptimizeRxAdjRssiAndPathAbsorption(allNodes, uniqueDeviceIds, optimization, existingSettings);
 
-            // Step 2: Optimize node-specific absorptions while keeping RxAdjRssi constant
-            var nodeAbsorptions = OptimizeNodeAbsorptions(allNodes, uniqueDeviceIds, rxAdjRssiDict, pathAbsorptionDict, optimization, existingSettings);
+            // Step 1: Optimize RxAdjRssi and path-specific absorptions
+            var (rxAdjRssiDict, pathAbsorptionDict, txRefRssiDict, _) = OptimizeRxAdjRssiAndPathAbsorption(allNodes, uniqueDeviceIds, optimization, existingSettings);
+
+            // Step 2: Optimize node-specific absorptions and antenna pointing (sinAz/cosAz/sinEl) while keeping RxAdjRssi constant
+            var (nodeAbsorptions, nodeAzimuths, nodeElevations, nodeError) = OptimizeNodeAbsorptions(allNodes, uniqueDeviceIds, rxAdjRssiDict, pathAbsorptionDict, optimization, existingSettings);
 
             // Process and store results
             foreach (var deviceId in uniqueDeviceIds)
@@ -42,12 +49,16 @@ public class CombinedOptimizer : IOptimizer
                 if (rxAdjRssiDict.TryGetValue(deviceId, out var rxAdjRssi) &&
                     nodeAbsorptions.TryGetValue(deviceId, out var absorption))
                 {
-                    results.Nodes[deviceId] = new ProposedValues
+                    var proposed = new ProposedValues
                     {
                         RxAdjRssi = rxAdjRssi,
                         Absorption = absorption,
-                        Error = error
+                        Error = nodeError
                     };
+                    if (txRefRssiDict.TryGetValue(deviceId, out var txRefRssi)) proposed.TxRefRssi = txRefRssi;
+                    if (nodeAzimuths.TryGetValue(deviceId, out var az)) proposed.Azimuth = az;
+                    if (nodeElevations.TryGetValue(deviceId, out var el)) proposed.Elevation = el;
+                    results.Nodes[deviceId] = proposed;
                 }
             }
         }
@@ -59,7 +70,7 @@ public class CombinedOptimizer : IOptimizer
         return results;
     }
 
-    private (Dictionary<string, double> RxAdjRssi, Dictionary<(string, string), double> PathAbsorption, double Error)
+    private (Dictionary<string, double> RxAdjRssi, Dictionary<(string, string), double> PathAbsorption, Dictionary<string, double> TxRefRssi, double Error)
         OptimizeRxAdjRssiAndPathAbsorption(List<Measure> allNodes, List<string> uniqueDeviceIds, ConfigOptimization optimization, Dictionary<string, NodeSettings> existingSettings)
     {
         var pathPairs = new HashSet<(string, string)>(allNodes.Select(n => (Min(n.Rx.Id, n.Tx.Id), Max(n.Rx.Id, n.Tx.Id))));
@@ -72,7 +83,6 @@ public class CombinedOptimizer : IOptimizer
             for (int i = 0; i < uniqueDeviceIds.Count; i++)
             {
                 var rxAdjRssi = x[i];
-                existingSettings.TryGetValue(uniqueDeviceIds[i], out var nodeSettings);
                 // Bounds should always come from global config
                 double rxAdjMin = optimization?.RxAdjRssiMin ?? -15;
                 double rxAdjMax = optimization?.RxAdjRssiMax ?? 25;
@@ -124,21 +134,36 @@ public class CombinedOptimizer : IOptimizer
             pathAbsorptionDict[pair] = result.MinimizingPoint[pathOffset++];
         }
 
-        return (rxAdjRssiDict, pathAbsorptionDict, result.FunctionInfoAtMinimum.Value);
+        var txRefRssiDict = rxAdjRssiDict.ToDictionary(kvp => kvp.Key, kvp => BaseTxRefRssi + kvp.Value);
+
+        return (rxAdjRssiDict, pathAbsorptionDict, txRefRssiDict, result.FunctionInfoAtMinimum.Value);
     }
 
-    private Dictionary<string, double> OptimizeNodeAbsorptions(List<Measure> allNodes, List<string> uniqueDeviceIds,
+    private (NodeAbsorptionMap Absorptions, NodeAzimuthMap Azimuths, NodeElevationMap Elevations, double Error) OptimizeNodeAbsorptions(List<Measure> allNodes, List<string> uniqueDeviceIds,
         Dictionary<string, double> rxAdjRssiDict, Dictionary<(string, string), double> pathAbsorptionDict, ConfigOptimization optimization, Dictionary<string, NodeSettings> existingSettings)
     {
-        // Fix: Use ObjectiveFunction.Gradient() instead of ValueAndGradient
+        int absorptionCount = uniqueDeviceIds.Count;
+        var directionalDeviceIds = allNodes
+            .SelectMany(m => new[] {
+                (m.Rx.Id, m.Rx.IsNode, m.Rx.HasDirectionalAntenna),
+                (m.Tx.Id, m.Tx.IsNode, m.Tx.HasDirectionalAntenna) })
+            .Where(t => t.IsNode && t.HasDirectionalAntenna)
+            .Select(t => t.Id)
+            .Distinct()
+            .ToList();
+        int directionalCount = directionalDeviceIds.Count;
+        int vecLen = Step2Layout.VectorLength(absorptionCount, directionalCount);
+
+        // Use ObjectiveFunction.Gradient() with gradient over the full 4N vector.
+        // Both absorption and antenna direction parameters are optimised simultaneously
+        // using gain-corrected error plus unit-circle regularisation.
         var obj = ObjectiveFunction.Gradient(
             x => {
+                var xa = x.ToArray();
                 var nodeAbsorptionDict = new Dictionary<string, double>();
-                for (int i = 0; i < uniqueDeviceIds.Count; i++)
+                for (int i = 0; i < absorptionCount; i++)
                 {
-                    var absorption = x[i];
-                    existingSettings.TryGetValue(uniqueDeviceIds[i], out var nodeSettings);
-                    // Bounds should always come from global config
+                    var absorption = xa[Step2Layout.AbsIndex(i, absorptionCount)];
                     double absorptionMin = optimization?.AbsorptionMin ?? 2.5;
                     double absorptionMax = optimization?.AbsorptionMax ?? 3.5;
                     if (absorption < absorptionMin || absorption > absorptionMax)
@@ -146,57 +171,158 @@ public class CombinedOptimizer : IOptimizer
                     nodeAbsorptionDict[uniqueDeviceIds[i]] = absorption;
                 }
 
-                return CalculateError(allNodes, rxAdjRssiDict, nodeAbsorptionDict: nodeAbsorptionDict);
-            },
-            x => {
-                var nodeAbsorptionDict = new Dictionary<string, double>();
-                for (int i = 0; i < uniqueDeviceIds.Count; i++)
+                // Build working direction dictionary from sin/cos params
+                var dirDict = new Dictionary<string, (double azRad, double elRad)>();
+                for (int i = 0; i < directionalCount; i++)
                 {
-                    nodeAbsorptionDict[uniqueDeviceIds[i]] = x[i];
+                    dirDict[directionalDeviceIds[i]] = (
+                        Step2Layout.GetAzimuthRad(xa, i, absorptionCount, directionalCount),
+                        Step2Layout.GetElevationRad(xa, i, absorptionCount, directionalCount)
+                    );
                 }
 
-                // Numerically approximate the gradient
-                var gradient = Vector<double>.Build.Dense(x.Count);
-                double epsilon = 1e-5;
-                double baseError = CalculateError(allNodes, rxAdjRssiDict, nodeAbsorptionDict: nodeAbsorptionDict);
+                // Regularization: sum of unit-circle penalties
+                double penalty = 0.0;
+                for (int i = 0; i < directionalCount; i++)
+                    penalty += Step2Layout.UnitCirclePenalty(xa, i, absorptionCount, directionalCount);
 
-                for (int i = 0; i < x.Count; i++)
+                double error = CalculateErrorWithGain(allNodes, rxAdjRssiDict, nodeAbsorptionDict, dirDict);
+                return error + penalty;
+            },
+            x => {
+                var xa = x.ToArray();
+                var nodeAbsorptionDict = new Dictionary<string, double>();
+                for (int i = 0; i < absorptionCount; i++)
+                    nodeAbsorptionDict[uniqueDeviceIds[i]] = xa[Step2Layout.AbsIndex(i, absorptionCount)];
+
+                var dirDict = new Dictionary<string, (double azRad, double elRad)>();
+                for (int i = 0; i < directionalCount; i++)
                 {
-                    var tempDict = new Dictionary<string, double>(nodeAbsorptionDict);
-                    tempDict[uniqueDeviceIds[i]] += epsilon;
+                    dirDict[directionalDeviceIds[i]] = (
+                        Step2Layout.GetAzimuthRad(xa, i, absorptionCount, directionalCount),
+                        Step2Layout.GetElevationRad(xa, i, absorptionCount, directionalCount)
+                    );
+                }
 
-                    var errorPlusEps = CalculateError(allNodes, rxAdjRssiDict, nodeAbsorptionDict: tempDict);
-                    gradient[i] = (errorPlusEps - baseError) / epsilon;
+                // Full 4N gradient via finite differences over all parameters
+                var gradient = Vector<double>.Build.Dense(vecLen);
+                double eps = 1e-5;
+
+                double baseError = CalculateErrorWithGain(allNodes, rxAdjRssiDict, nodeAbsorptionDict, dirDict);
+                double basePenalty = 0.0;
+                for (int i = 0; i < directionalCount; i++)
+                    basePenalty += Step2Layout.UnitCirclePenalty(xa, i, absorptionCount, directionalCount);
+                double baseVal = baseError + basePenalty;
+
+                for (int j = 0; j < vecLen; j++)
+                {
+                    var xPlus = xa.ToArray(); // copy
+                    xPlus[j] += eps;
+
+                    var absPlus = new Dictionary<string, double>(nodeAbsorptionDict);
+                    for (int i = 0; i < absorptionCount; i++)
+                        absPlus[uniqueDeviceIds[i]] = xPlus[Step2Layout.AbsIndex(i, absorptionCount)];
+
+                    var dirPlus = new Dictionary<string, (double azRad, double elRad)>();
+                    for (int i = 0; i < directionalCount; i++)
+                    {
+                        dirPlus[directionalDeviceIds[i]] = (
+                            Step2Layout.GetAzimuthRad(xPlus, i, absorptionCount, directionalCount),
+                            Step2Layout.GetElevationRad(xPlus, i, absorptionCount, directionalCount)
+                        );
+                    }
+
+                    double penPlus = 0.0;
+                    for (int i = 0; i < directionalCount; i++)
+                        penPlus += Step2Layout.UnitCirclePenalty(xPlus, i, absorptionCount, directionalCount);
+
+                    double errPlus = CalculateErrorWithGain(allNodes, rxAdjRssiDict, absPlus, dirPlus);
+                    gradient[j] = (errPlus + penPlus - baseVal) / eps;
                 }
 
                 return gradient;
             });
 
-        // Initial guess uses node setting if available, else global midpoint
-        var initialGuess = Vector<double>.Build.Dense(uniqueDeviceIds.Count);
-        for (int i = 0; i < uniqueDeviceIds.Count; i++)
+        // -----------------------------------------------------------------------
+        // Initial-guess vector (4N): abs block seeded from calibration, antenna
+        // blocks seeded to boresight-pointing identity (azimuth=0, elevation=0).
+        // -----------------------------------------------------------------------
+        var initialGuessArr = new double[vecLen];
+        for (int i = 0; i < absorptionCount; i++)
         {
             existingSettings.TryGetValue(uniqueDeviceIds[i], out var nodeSettings);
-            double absorptionMin = optimization?.AbsorptionMin ?? 2.5; // Need global bounds for fallback midpoint
+            double absorptionMin = optimization?.AbsorptionMin ?? 2.5;
             double absorptionMax = optimization?.AbsorptionMax ?? 3.5;
-            // Clamp initial guess within global bounds
-            initialGuess[i] = Math.Clamp(nodeSettings?.Calibration?.Absorption ?? (absorptionMax - absorptionMin) / 2 + absorptionMin, absorptionMin, absorptionMax);
+            // Abs block: clamp existing calibration value within global bounds
+            initialGuessArr[Step2Layout.AbsIndex(i, absorptionCount)] = Math.Clamp(
+                nodeSettings?.Calibration?.Absorption ?? (absorptionMax - absorptionMin) / 2 + absorptionMin,
+                absorptionMin, absorptionMax);
         }
-
-        var solver = new BfgsMinimizer(1e-7, 1e-7, 1e-7);
-        var result = solver.FindMinimum(obj, initialGuess);
-
-        var nodeAbsorptions = new Dictionary<string, double>();
-        for (int i = 0; i < uniqueDeviceIds.Count; i++)
+        for (int i = 0; i < directionalCount; i++)
         {
-            nodeAbsorptions[uniqueDeviceIds[i]] = result.MinimizingPoint[i];
+            existingSettings.TryGetValue(directionalDeviceIds[i], out var nodeSettings);
+            double azDeg = nodeSettings?.Calibration?.Azimuth ?? 0.0;
+            double elDeg = nodeSettings?.Calibration?.Elevation ?? 0.0; // Default horizontal for optimizer (node-to-node paths)
+            double azRad = azDeg * Math.PI / 180.0;
+            double elRad = elDeg * Math.PI / 180.0;
+            initialGuessArr[Step2Layout.SinAzIndex(i, absorptionCount, directionalCount)] = Math.Sin(azRad);
+            initialGuessArr[Step2Layout.CosAzIndex(i, absorptionCount, directionalCount)] = Math.Cos(azRad);
+            initialGuessArr[Step2Layout.SinElIndex(i, absorptionCount, directionalCount)] = Math.Sin(elRad);
         }
+        var initialGuess = Vector<double>.Build.DenseOfArray(initialGuessArr);
 
-        return nodeAbsorptions;
+        // -----------------------------------------------------------------------
+        // Lower / upper bound vectors (4N) wired to Step2Layout offsets.
+        // Abs block: global absorption range.
+        // sinAz/cosAz: loose [-2, 2] — regularisation pulls them to the unit circle.
+        // sinEl: strict [-1, 1] — sin(elevation) is always in this range.
+        // -----------------------------------------------------------------------
+        var lowerBoundArr = new double[vecLen];
+        var upperBoundArr = new double[vecLen];
+        for (int i = 0; i < absorptionCount; i++)
+        {
+            double absorptionMin = optimization?.AbsorptionMin ?? 2.5;
+            double absorptionMax = optimization?.AbsorptionMax ?? 3.5;
+            lowerBoundArr[Step2Layout.AbsIndex(i, absorptionCount)] = absorptionMin;
+            upperBoundArr[Step2Layout.AbsIndex(i, absorptionCount)] = absorptionMax;
+        }
+        for (int i = 0; i < directionalCount; i++)
+        {
+            lowerBoundArr[Step2Layout.SinAzIndex(i, absorptionCount, directionalCount)] = -2.0;
+            upperBoundArr[Step2Layout.SinAzIndex(i, absorptionCount, directionalCount)] =  2.0;
+            lowerBoundArr[Step2Layout.CosAzIndex(i, absorptionCount, directionalCount)] = -2.0;
+            upperBoundArr[Step2Layout.CosAzIndex(i, absorptionCount, directionalCount)] =  2.0;
+            lowerBoundArr[Step2Layout.SinElIndex(i, absorptionCount, directionalCount)] = -1.0;
+            upperBoundArr[Step2Layout.SinElIndex(i, absorptionCount, directionalCount)] =  1.0;
+        }
+        var lowerBound = Vector<double>.Build.DenseOfArray(lowerBoundArr);
+        var upperBound = Vector<double>.Build.DenseOfArray(upperBoundArr);
+
+        var solver = new BfgsBMinimizer(1e-7, 1e-7, 1e-7, 10000);
+        var result = solver.FindMinimum(obj, lowerBound, upperBound, initialGuess);
+
+        var minPoint = result.MinimizingPoint.ToArray();
+        var nodeAbsorptions = new NodeAbsorptionMap();
+        for (int i = 0; i < absorptionCount; i++)
+            nodeAbsorptions[uniqueDeviceIds[i]] = minPoint[Step2Layout.AbsIndex(i, absorptionCount)];
+
+        var nodeAzimuths = new NodeAzimuthMap();
+        var nodeElevations = new NodeElevationMap();
+        for (int i = 0; i < directionalCount; i++)
+        {
+            double azRad = Step2Layout.GetAzimuthRad(minPoint, i, absorptionCount, directionalCount);
+            double elRad = Step2Layout.GetElevationRad(minPoint, i, absorptionCount, directionalCount);
+            double azDeg = azRad * 180.0 / Math.PI;
+            if (azDeg < 0) azDeg += 360.0;
+            double elDeg = elRad * 180.0 / Math.PI;
+            nodeAzimuths[directionalDeviceIds[i]] = azDeg;
+            nodeElevations[directionalDeviceIds[i]] = elDeg;
+        }
+        return (Absorptions: nodeAbsorptions, Azimuths: nodeAzimuths, Elevations: nodeElevations, Error: result.FunctionInfoAtMinimum.Value);
     }
 
     private double CalculateError(List<Measure> nodes, Dictionary<string, double> rxAdjRssiDict,
-        Dictionary<string, double> nodeAbsorptionDict = null, Dictionary<(string, string), double> pathAbsorptionDict = null)
+        Dictionary<string, double>? nodeAbsorptionDict = null, Dictionary<(string, string), double>? pathAbsorptionDict = null)
     {
         return nodes.Select(n =>
         {
@@ -219,9 +345,43 @@ public class CombinedOptimizer : IOptimizer
                 throw new ArgumentException("Either nodeAbsorptionDict or pathAbsorptionDict must be provided");
             }
 
-            var calculatedDistance = Math.Pow(10, (-59 + rxAdjRssi + txAdjRssi - n.Rssi) / (10.0d * absorption));
+            var calculatedDistance = Math.Pow(10, (BaseTxRefRssi + rxAdjRssi + txAdjRssi - n.Rssi) / (10.0d * absorption));
             return Math.Pow(distance - calculatedDistance, 2);
         }).Average();
+    }
+
+    private double CalculateErrorWithGain(List<Measure> nodes, Dictionary<string, double> rxAdjRssiDict,
+        Dictionary<string, double> nodeAbsorptionDict, Dictionary<string, (double azRad, double elRad)> dirDict)
+    {
+        return nodes.Select(n =>
+        {
+            var distance = n.Rx.Location.DistanceTo(n.Tx.Location);
+            var rxAdjRssi = rxAdjRssiDict[n.Rx.Id];
+            var txAdjRssi = rxAdjRssiDict[n.Tx.Id];
+            var absorption = (nodeAbsorptionDict[n.Rx.Id] + nodeAbsorptionDict[n.Tx.Id]) / 2;
+
+            double gainDb = 0.0;
+            if (n.Rx.IsNode && n.Rx.HasDirectionalAntenna && dirDict.TryGetValue(n.Rx.Id, out var rxDir))
+                gainDb += ComputeGainDb(n.Rx, n.Tx, rxDir.azRad, rxDir.elRad);
+            if (n.Tx.IsNode && n.Tx.HasDirectionalAntenna && dirDict.TryGetValue(n.Tx.Id, out var txDir))
+                gainDb += ComputeGainDb(n.Tx, n.Rx, txDir.azRad, txDir.elRad);
+
+            var calculatedDistance = Math.Pow(10, (BaseTxRefRssi + rxAdjRssi + gainDb + txAdjRssi - n.Rssi) / (10.0d * absorption));
+            return Math.Pow(distance - calculatedDistance, 2);
+        }).Average();
+    }
+
+    private static double ComputeGainDb(OptNode rxNode, OptNode txNode, double azRad, double elRad)
+    {
+        double px = Math.Sin(azRad) * Math.Cos(elRad);
+        double py = Math.Cos(azRad) * Math.Cos(elRad);
+        double pz = Math.Sin(elRad);
+
+        return MathUtils.ComputeGainDb(px, py, pz,
+            txNode.Location.X - rxNode.Location.X,
+            txNode.Location.Y - rxNode.Location.Y,
+            txNode.Location.Z - rxNode.Location.Z,
+            10.0 * Math.Log10(rxNode.GMax), rxNode.PatternExponent, rxNode.BackLossDb);
     }
 
     private static string Min(string a, string b) => string.Compare(a, b) < 0 ? a : b;

--- a/src/Optimizers/GlobalAbsorptionRxTxOptimizer.cs
+++ b/src/Optimizers/GlobalAbsorptionRxTxOptimizer.cs
@@ -1,4 +1,5 @@
 using ESPresense.Models;
+using ESPresense.Utils;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.Optimization;
 using Serilog;
@@ -10,10 +11,7 @@ public class GlobalAbsorptionRxTxOptimizer : IOptimizer
 {
     private readonly State _state;
 
-    // Parameter to control asymmetric error weighting
-    // Higher value means we penalize "impossible" cases more strongly
     private const double AsymmetricErrorFactor = 5;
-    // Capped error value to prevent extreme outliers from skewing results
     private const double CappedError = 2560;
 
     public GlobalAbsorptionRxTxOptimizer(State state)
@@ -21,321 +19,378 @@ public class GlobalAbsorptionRxTxOptimizer : IOptimizer
         _state = state;
     }
 
-    public string Name => "Global Absorption Rx Tx Adj";
+    public string Name => "Global Absorption Rx Adj + Antenna";
 
     public OptimizationResults Optimize(OptimizationSnapshot os, Dictionary<string, NodeSettings> existingSettings)
     {
         var or = new OptimizationResults();
         var optimization = _state.Config?.Optimization;
-
         if (optimization == null) return or;
 
-        // Group all valid measurements
-        var allRxNodes = os.ByRx().SelectMany(g => g).ToList();
-
-        if (allRxNodes.Count < 3)
+        var allMeasures = os.ByRx().SelectMany(g => g).ToList();
+        if (allMeasures.Count < 3)
         {
-            Log.Warning("Not enough valid measurements for optimization. Found {Count} measurements, need at least 3. Add more BLE beacons or ESPresense nodes.", allRxNodes.Count);
+            Log.Warning("Not enough valid measurements for optimization. Found {Count}, need 3+.", allMeasures.Count);
             return or;
         }
 
-        // Get unique Rx and Tx nodes
-        var uniqueRxIds = allRxNodes.Select(n => n.Rx.Id).Distinct().ToList();
-        var uniqueTxIds = allRxNodes.Select(n => n.Tx.Id).Distinct().ToList();
+        var uniqueRxIds = allMeasures.Select(m => m.Rx.Id).Distinct().ToList();
+        var uniqueTxIds = allMeasures.Select(m => m.Tx.Id).Distinct().ToList();
+        var directionalNodeIds = allMeasures
+            .SelectMany(m => new[] { m.Rx, m.Tx })
+            .Where(n => n.IsNode && n.HasDirectionalAntenna)
+            .Select(n => n.Id)
+            .Distinct()
+            .ToList();
 
-        // Map parameter indices
+        var weights = PreCalculateWeights(allMeasures);
+
+        // Phase 1: Global absorption + per-Rx rxAdj + per-Tx txRef (isotropic, no gain)
+        Phase1_IsotropicRxAdj(or, allMeasures, uniqueRxIds, uniqueTxIds, weights, optimization, existingSettings);
+
+        // Phase 2: Antenna angles only, holding absorption + rxAdj + txRef fixed
+        if (directionalNodeIds.Count > 0 && or.Nodes.Count > 0)
+            Phase2_AntennaAngles(or, allMeasures, directionalNodeIds, weights, optimization, existingSettings);
+
+        return or;
+    }
+
+    /// <summary>
+    /// Phase 1: Standard isotropic optimization of global absorption, per-Rx rxAdjRssi, per-Tx txRefRssi.
+    /// No antenna gain correction — proven convergence path.
+    /// </summary>
+    private void Phase1_IsotropicRxAdj(OptimizationResults or, List<Measure> allMeasures,
+        List<string> uniqueRxIds, List<string> uniqueTxIds,
+        Dictionary<Measure, double> weights, ConfigOptimization optimization,
+        Dictionary<string, NodeSettings> existingSettings)
+    {
         var rxIndexMap = new Dictionary<string, int>();
         var txIndexMap = new Dictionary<string, int>();
         int paramIndex = 0;
-
-        // Global absorption parameter is the first parameter
-        int globalAbsorptionIndex = paramIndex++;
-
-        // Each Rx node has one parameter: rxAdjRssi
-        foreach (var rxId in uniqueRxIds)
-        {
-            rxIndexMap[rxId] = paramIndex++;
-        }
-
-        // Each Tx node has one parameter: txRefRssi
-        foreach (var txId in uniqueTxIds)
-        {
-            txIndexMap[txId] = paramIndex++;
-        }
-
+        int absorptionIdx = paramIndex++;
+        foreach (var rxId in uniqueRxIds) rxIndexMap[rxId] = paramIndex++;
+        foreach (var txId in uniqueTxIds) txIndexMap[txId] = paramIndex++;
         int totalParams = paramIndex;
 
-        // Pre-calculate weights for each node based on RssiVar
-        var nodeWeights = new Dictionary<Measure, double>();
-        double totalWeight = 0;
-
-        foreach (var node in allRxNodes)
-        {
-            // Inverse variance weighting - use 1/variance as weight
-            double weight = 1.0;
-            if (node.RssiVar > 0)
-            {
-                weight = 1.0 / Math.Max(node.RssiVar.Value, 0.1); // Adding minimum to avoid extreme weights
-            }
-
-            nodeWeights[node] = weight;
-            totalWeight += weight;
-        }
-
-        // Normalize weights if needed
-        if (totalWeight > 0)
-        {
-            foreach (var node in allRxNodes)
-            {
-                nodeWeights[node] = nodeWeights[node] / totalWeight * allRxNodes.Count;
-            }
-        }
-
-        var objectiveFunction = ObjectiveFunction.Gradient(
+        var obj = ObjectiveFunction.Gradient(
             x =>
             {
-                double squaredErrorSum = 0;
-                double weightSum = 0;
+                double absorption = x[absorptionIdx];
+                double squaredErrorSum = 0, weightSum = 0;
 
-                // Get the global absorption value
-                double globalAbsorption = x[globalAbsorptionIndex];
-
-                foreach (var node in allRxNodes)
+                foreach (var m in allMeasures)
                 {
-                    if (node.Rx?.Location == null || node.Tx?.Location == null)
-                    {
-                        continue; // Skip measurements with missing locations
-                    }
+                    if (m.Rx?.Location == null || m.Tx?.Location == null) continue;
+                    double rxAdj = x[rxIndexMap[m.Rx.Id]];
+                    double txRef = x[txIndexMap[m.Tx.Id]];
+                    double mapDist = Math.Max(m.Rx.Location.DistanceTo(m.Tx.Location), 0.1);
 
-                    int rxIndex = rxIndexMap[node.Rx.Id];
-                    int txIndex = txIndexMap[node.Tx.Id];
+                    double predicted = txRef - 10 * absorption * Math.Log10(mapDist);
+                    double diff = predicted - m.GetAdjustedRssi(rxAdj);
 
-                    double rxAdjRssi = x[rxIndex];
-                    double txRefRssi = x[txIndex];
-
-                    double mapDistance = node.Rx.Location.DistanceTo(node.Tx.Location);
-                    if (mapDistance <= 0)
-                    {
-                        mapDistance = 0.1; // Prevent log(0) error
-                    }
-
-                    // Calculate the predicted RSSI using the path loss model
-                    double predictedRssi = txRefRssi - 10 * globalAbsorption * Math.Log10(mapDistance);
-                    double adjustedMeasuredRssi = node.GetAdjustedRssi(rxAdjRssi);
-                    // Compare with the adjusted measured RSSI
-                    double diff = predictedRssi - adjustedMeasuredRssi;
-
-                    // Get the weight for this node
-                    double weight = nodeWeights[node];
-                    weightSum += weight;
-
-                    // Calculate error with asymmetric penalty
-                    double error;
-                    if (diff < 0)
-                    {
-                        // Predicted RSSI is less than the adjusted measured RSSI
-                        error = Math.Min(AsymmetricErrorFactor * Math.Pow(diff, 2), CappedError);
-                    }
-                    else
-                    {
-                        error = Math.Min(Math.Pow(diff, 2), CappedError);
-                    }
-
-                    squaredErrorSum += weight * error;
+                    double w = weights[m];
+                    weightSum += w;
+                    double error = diff < 0
+                        ? Math.Min(AsymmetricErrorFactor * diff * diff, CappedError)
+                        : Math.Min(diff * diff, CappedError);
+                    squaredErrorSum += w * error;
                 }
-
                 return weightSum > 0 ? squaredErrorSum / weightSum : squaredErrorSum;
             },
             x =>
             {
                 var grad = Vector<double>.Build.Dense(totalParams);
-                double h = 1e-6;
+                const double h = 1e-6;
                 for (int i = 0; i < totalParams; i++)
                 {
-                    var xPlus = x.Clone();
-                    var xMinus = x.Clone();
-                    xPlus[i] = x[i] + h;
-                    xMinus[i] = x[i] - h;
-
-                    double fPlus = 0;
-                    double fMinus = 0;
-                    double weightSumPlus = 0;
-                    double weightSumMinus = 0;
-
-                    foreach (var measure in allRxNodes)
+                    var xPlus = x.Clone(); xPlus[i] += h;
+                    var xMinus = x.Clone(); xMinus[i] -= h;
+                    grad[i] = (((Func<Vector<double>, double>)(v =>
                     {
-                        if (measure.Rx?.Location == null || measure.Tx?.Location == null)
+                        double absorption = v[absorptionIdx];
+                        double se = 0, ws = 0;
+                        foreach (var m in allMeasures)
                         {
-                            continue;
+                            if (m.Rx?.Location == null || m.Tx?.Location == null) continue;
+                            double rxAdj = v[rxIndexMap[m.Rx.Id]];
+                            double txRef = v[txIndexMap[m.Tx.Id]];
+                            double mapDist = Math.Max(m.Rx.Location.DistanceTo(m.Tx.Location), 0.1);
+                            double predicted = txRef - 10 * absorption * Math.Log10(mapDist);
+                            double diff = predicted - m.GetAdjustedRssi(rxAdj);
+                            double w = weights[m]; ws += w;
+                            double err = diff < 0 ? Math.Min(AsymmetricErrorFactor * diff * diff, CappedError) : Math.Min(diff * diff, CappedError);
+                            se += w * err;
                         }
-
-                        int rxIndex = rxIndexMap[measure.Rx.Id];
-                        int txIndex = txIndexMap[measure.Tx.Id];
-                        double weight = nodeWeights[measure];
-                        double mapDistance = measure.Rx.Location.DistanceTo(measure.Tx.Location);
-                        if (mapDistance <= 0)
+                        return ws > 0 ? se / ws : se;
+                    }))(xPlus) - ((Func<Vector<double>, double>)(v =>
+                    {
+                        double absorption = v[absorptionIdx];
+                        double se = 0, ws = 0;
+                        foreach (var m in allMeasures)
                         {
-                            mapDistance = 0.1;
+                            if (m.Rx?.Location == null || m.Tx?.Location == null) continue;
+                            double rxAdj = v[rxIndexMap[m.Rx.Id]];
+                            double txRef = v[txIndexMap[m.Tx.Id]];
+                            double mapDist = Math.Max(m.Rx.Location.DistanceTo(m.Tx.Location), 0.1);
+                            double predicted = txRef - 10 * absorption * Math.Log10(mapDist);
+                            double diff = predicted - m.GetAdjustedRssi(rxAdj);
+                            double w = weights[m]; ws += w;
+                            double err = diff < 0 ? Math.Min(AsymmetricErrorFactor * diff * diff, CappedError) : Math.Min(diff * diff, CappedError);
+                            se += w * err;
                         }
-
-                        // Plus calculation
-                        {
-                            double globalAbsorption = xPlus[globalAbsorptionIndex];
-                            double rxAdjRssi = xPlus[rxIndex];
-                            double txRefRssi = xPlus[txIndex];
-
-                            double predictedRssi = txRefRssi - 10 * globalAbsorption * Math.Log10(mapDistance);
-                            double diff = predictedRssi - measure.GetAdjustedRssi(rxAdjRssi);
-
-                            double error;
-                            if (diff < 0)
-                            {
-                                error = Math.Min(AsymmetricErrorFactor * Math.Pow(diff, 2), CappedError);
-                            }
-                            else
-                            {
-                                error = Math.Min(Math.Pow(diff, 2), CappedError);
-                            }
-
-                            fPlus += weight * error;
-                            weightSumPlus += weight;
-                        }
-
-                        // Minus calculation
-                        {
-                            double globalAbsorption = xMinus[globalAbsorptionIndex];
-                            double rxAdjRssi = xMinus[rxIndex];
-                            double txRefRssi = xMinus[txIndex];
-
-                            double predictedRssi = txRefRssi - 10 * globalAbsorption * Math.Log10(mapDistance);
-                            double diff = predictedRssi - measure.GetAdjustedRssi(rxAdjRssi);
-
-                            double error;
-                            if (diff < 0)
-                            {
-                                error = Math.Min(AsymmetricErrorFactor * Math.Pow(diff, 2), CappedError);
-                            }
-                            else
-                            {
-                                error = Math.Min(Math.Pow(diff, 2), CappedError);
-                            }
-
-                            fMinus += weight * error;
-                            weightSumMinus += weight;
-                        }
-                    }
-
-                    fPlus = weightSumPlus > 0 ? fPlus / weightSumPlus : fPlus;
-                    fMinus = weightSumMinus > 0 ? fMinus / weightSumMinus : fMinus;
-                    grad[i] = (fPlus - fMinus) / (2 * h);
+                        return ws > 0 ? se / ws : se;
+                    }))(xMinus)) / (2 * h);
                 }
                 return grad;
             }
         );
 
-        // Build lower and upper bound vectors
-        var lowerBound = Vector<double>.Build.Dense(totalParams);
-        var upperBound = Vector<double>.Build.Dense(totalParams);
+        var lower = Vector<double>.Build.Dense(totalParams);
+        var upper = Vector<double>.Build.Dense(totalParams);
+        var initial = Vector<double>.Build.Dense(totalParams);
 
-        // Set bounds for global absorption
-        lowerBound[globalAbsorptionIndex] = optimization.AbsorptionMin;
-        upperBound[globalAbsorptionIndex] = optimization.AbsorptionMax;
-
-        // For Rx nodes: rxAdjRssi bounds
-        foreach (var rxId in uniqueRxIds)
-        {
-            lowerBound[rxIndexMap[rxId]] = optimization.RxAdjRssiMin;
-            upperBound[rxIndexMap[rxId]] = optimization.RxAdjRssiMax;
-        }
-
-        // For Tx nodes: txRefRssi bounds
-        foreach (var txId in uniqueTxIds)
-        {
-            lowerBound[txIndexMap[txId]] = optimization.TxRefRssiMin;
-            upperBound[txIndexMap[txId]] = optimization.TxRefRssiMax;
-        }
-
-        // Initialize with a reasonable guess (ensure within bounds)
-        var initialGuess = Vector<double>.Build.Dense(totalParams);
-
-        // Calculate the average absorption from existing settings for initial guess
+        lower[absorptionIdx] = optimization.AbsorptionMin;
+        upper[absorptionIdx] = optimization.AbsorptionMax;
         var validAbsorptions = existingSettings.Values
-            .Select(ns => ns.Calibration?.Absorption)
-            .Where(a => a.HasValue)
-            .Select(a => a!.Value)
-            .ToList();
+            .Select(ns => ns.Calibration?.Absorption).Where(a => a.HasValue).Select(a => a!.Value).ToList();
+        initial[absorptionIdx] = Math.Clamp(
+            validAbsorptions.Any() ? validAbsorptions.Average() : (optimization.AbsorptionMin + optimization.AbsorptionMax) / 2.0,
+            optimization.AbsorptionMin, optimization.AbsorptionMax);
 
-        double initialGlobalAbsorptionGuess;
-        if (validAbsorptions.Any())
-        {
-            initialGlobalAbsorptionGuess = validAbsorptions.Average();
-        }
-        else
-        {
-            // Fallback to midpoint if no nodes have absorption set
-            initialGlobalAbsorptionGuess = (optimization.AbsorptionMax + optimization.AbsorptionMin) / 2.0;
-        }
-        // Clamp the initial guess for global absorption
-        initialGuess[globalAbsorptionIndex] = Math.Clamp(initialGlobalAbsorptionGuess, optimization.AbsorptionMin, optimization.AbsorptionMax);
-
-        // Initialize Rx node parameters
         foreach (var rxId in uniqueRxIds)
         {
-            existingSettings.TryGetValue(rxId, out var nodeSettings);
-            // Clamp initial guess within global bounds
-            initialGuess[rxIndexMap[rxId]] = Math.Clamp(nodeSettings?.Calibration?.RxAdjRssi ?? 0, optimization.RxAdjRssiMin, optimization.RxAdjRssiMax);
+            int idx = rxIndexMap[rxId];
+            lower[idx] = optimization.RxAdjRssiMin;
+            upper[idx] = optimization.RxAdjRssiMax;
+            existingSettings.TryGetValue(rxId, out var ns);
+            initial[idx] = Math.Clamp(ns?.Calibration?.RxAdjRssi ?? 0, optimization.RxAdjRssiMin, optimization.RxAdjRssiMax);
         }
-
-        // Initialize Tx node parameters
         foreach (var txId in uniqueTxIds)
         {
-            existingSettings.TryGetValue(txId, out var nodeSettings);
-            // Clamp initial guess within global bounds
-            initialGuess[txIndexMap[txId]] = Math.Clamp(nodeSettings?.Calibration?.TxRefRssi ?? -59, optimization.TxRefRssiMin, optimization.TxRefRssiMax);
+            int idx = txIndexMap[txId];
+            lower[idx] = optimization.TxRefRssiMin;
+            upper[idx] = optimization.TxRefRssiMax;
+            existingSettings.TryGetValue(txId, out var ns);
+            initial[idx] = Math.Clamp(ns?.Calibration?.TxRefRssi ?? -59, optimization.TxRefRssiMin, optimization.TxRefRssiMax);
         }
 
         try
         {
-            // Use the bounded BFGS solver
             var solver = new BfgsBMinimizer(1e-8, 1e-8, 1e-8, 10000);
-            var result = solver.FindMinimum(objectiveFunction, lowerBound, upperBound, initialGuess);
+            var result = solver.FindMinimum(obj, lower, upper, initial);
 
-            // Get the optimized global absorption value
-            double globalAbsorptionValue = result.MinimizingPoint[globalAbsorptionIndex];
-            globalAbsorptionValue = Math.Max(optimization.AbsorptionMin, Math.Min(globalAbsorptionValue, optimization.AbsorptionMax));
-
-            // Process Rx node results
+            double absorption = Math.Clamp(result.MinimizingPoint[absorptionIdx], optimization.AbsorptionMin, optimization.AbsorptionMax);
             foreach (var rxId in uniqueRxIds)
             {
-                double rxAdjRssi = result.MinimizingPoint[rxIndexMap[rxId]];
-                rxAdjRssi = Math.Max(optimization.RxAdjRssiMin, Math.Min(rxAdjRssi, optimization.RxAdjRssiMax));
-
+                double rxAdj = Math.Clamp(result.MinimizingPoint[rxIndexMap[rxId]], optimization.RxAdjRssiMin, optimization.RxAdjRssiMax);
                 var n = or.Nodes.GetOrAdd(rxId);
-                n.RxAdjRssi = rxAdjRssi;
-                n.Absorption = globalAbsorptionValue;
+                n.RxAdjRssi = rxAdj;
+                n.Absorption = absorption;
                 n.Error = result.FunctionInfoAtMinimum.Value;
             }
-
-            // Process Tx node results
             foreach (var txId in uniqueTxIds)
             {
-                double txRefRssi = result.MinimizingPoint[txIndexMap[txId]];
-                txRefRssi = Math.Max(optimization.TxRefRssiMin, Math.Min(txRefRssi, optimization.TxRefRssiMax));
-
+                double txRef = Math.Clamp(result.MinimizingPoint[txIndexMap[txId]], optimization.TxRefRssiMin, optimization.TxRefRssiMax);
                 var n = or.Nodes.GetOrAdd(txId);
-                n.TxRefRssi = txRefRssi;
+                n.TxRefRssi = txRef;
                 n.Error = result.FunctionInfoAtMinimum.Value;
             }
 
-            // Log the optimization results
-            Log.Debug(Name + " completed with error: {0}, global absorption: {1}",
-                result.FunctionInfoAtMinimum.Value, globalAbsorptionValue);
+            Log.Debug("{Name} Phase 1 completed with error: {Error}, absorption: {Absorption}", Name, result.FunctionInfoAtMinimum.Value, absorption);
         }
         catch (Exception ex)
         {
-            Log.Error("Error optimizing: {0}", ex.Message);
+            Log.Error("Error in {Name} Phase 1: {Message}", Name, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Phase 2: Optimize antenna angles only. Holds absorption/rxAdj/txRef fixed from Phase 1.
+    /// Uses Tx+Rx gain correction. Output angles quantized to 45°.
+    /// </summary>
+    private void Phase2_AntennaAngles(OptimizationResults or, List<Measure> allMeasures,
+        List<string> directionalNodeIds, Dictionary<Measure, double> weights,
+        ConfigOptimization optimization, Dictionary<string, NodeSettings> existingSettings)
+    {
+        // Build fixed parameter lookups from Phase 1
+        var fixedRxAdj = new Dictionary<string, double>();
+        var fixedTxRef = new Dictionary<string, double>();
+        double fixedAbsorption = 3.0;
+        foreach (var (id, pv) in or.Nodes)
+        {
+            if (pv.RxAdjRssi != null) fixedRxAdj[id] = pv.RxAdjRssi.Value;
+            if (pv.TxRefRssi != null) fixedTxRef[id] = pv.TxRefRssi.Value;
+            if (pv.Absorption != null) fixedAbsorption = pv.Absorption.Value;
         }
 
-        return or;
+        // Parameters: [sinAz_0, cosAz_0, sinEl_0, sinAz_1, cosAz_1, sinEl_1, ...]
+        int N = directionalNodeIds.Count;
+        int totalParams = N * 3;
+        var idxMap = new Dictionary<string, int>();
+        for (int i = 0; i < N; i++)
+            idxMap[directionalNodeIds[i]] = i * 3;
+
+        double EvalPhase2(double[] xa)
+        {
+            double squaredErrorSum = 0, weightSum = 0, penalty = 0;
+
+            // Unit-circle regularization
+            for (int i = 0; i < N; i++)
+            {
+                double sa = xa[i * 3], ca = xa[i * 3 + 1];
+                double dev = sa * sa + ca * ca - 1.0;
+                penalty += 0.1 * dev * dev;
+            }
+
+            foreach (var m in allMeasures)
+            {
+                if (m.Rx?.Location == null || m.Tx?.Location == null) continue;
+
+                double rxAdj = fixedRxAdj.GetValueOrDefault(m.Rx.Id, 0);
+                double txRef = fixedTxRef.GetValueOrDefault(m.Tx.Id, -59);
+                double mapDist = Math.Max(m.Rx.Location.DistanceTo(m.Tx.Location), 0.1);
+
+                double gainDb = ComputeLinkGainDb(xa, idxMap, m);
+                if (double.IsNaN(gainDb) || double.IsInfinity(gainDb)) continue;
+
+                double predicted = txRef + gainDb - 10 * fixedAbsorption * Math.Log10(mapDist);
+                double diff = predicted - m.GetAdjustedRssi(rxAdj);
+
+                double w = weights[m];
+                weightSum += w;
+                double error = diff < 0
+                    ? Math.Min(AsymmetricErrorFactor * diff * diff, CappedError)
+                    : Math.Min(diff * diff, CappedError);
+                squaredErrorSum += w * error;
+            }
+
+            return (weightSum > 0 ? squaredErrorSum / weightSum : squaredErrorSum) + penalty;
+        }
+
+        var obj = ObjectiveFunction.Gradient(
+            x => EvalPhase2(x.ToArray()),
+            x =>
+            {
+                var xa = x.ToArray();
+                var grad = Vector<double>.Build.Dense(totalParams);
+                const double h = 1e-5;
+                double baseVal = EvalPhase2(xa);
+                for (int i = 0; i < totalParams; i++)
+                {
+                    var xp = (double[])xa.Clone();
+                    xp[i] += h;
+                    grad[i] = (EvalPhase2(xp) - baseVal) / h;
+                }
+                return grad;
+            }
+        );
+
+        var lower = new double[totalParams];
+        var upper = new double[totalParams];
+        var init = new double[totalParams];
+        for (int i = 0; i < N; i++)
+        {
+            existingSettings.TryGetValue(directionalNodeIds[i], out var ns);
+            double azRad, elRad;
+            if (ns?.Calibration?.Azimuth != null && ns?.Calibration?.Elevation != null)
+            {
+                azRad = ns.Calibration.Azimuth.Value * Math.PI / 180.0;
+                elRad = ns.Calibration.Elevation.Value * Math.PI / 180.0;
+            }
+            else
+            {
+                // Seed toward centroid of other nodes
+                var thisNode = allMeasures.Select(m => m.Rx.Id == directionalNodeIds[i] ? m.Rx : m.Tx.Id == directionalNodeIds[i] ? m.Tx : null).First(n => n != null)!;
+                var others = allMeasures
+                    .Where(m => m.Rx.Id == directionalNodeIds[i] || m.Tx.Id == directionalNodeIds[i])
+                    .Select(m => m.Rx.Id == directionalNodeIds[i] ? m.Tx.Location : m.Rx.Location)
+                    .ToList();
+                double cx = others.Average(p => p.X) - thisNode.Location.X;
+                double cy = others.Average(p => p.Y) - thisNode.Location.Y;
+                double cz = others.Average(p => p.Z) - thisNode.Location.Z;
+                double cLen = Math.Sqrt(cx * cx + cy * cy + cz * cz);
+                if (cLen < 1e-9) { azRad = 0; elRad = 0; }
+                else
+                {
+                    azRad = Math.Atan2(cx, cy);
+                    elRad = Math.Asin(Math.Clamp(cz / cLen, -1.0, 1.0));
+                }
+            }
+
+            int b = i * 3;
+            init[b] = Math.Sin(azRad); lower[b] = -2.0; upper[b] = 2.0;
+            init[b + 1] = Math.Cos(azRad); lower[b + 1] = -2.0; upper[b + 1] = 2.0;
+            init[b + 2] = Math.Sin(elRad); lower[b + 2] = -1.0; upper[b + 2] = 1.0;
+        }
+
+        try
+        {
+            var solver = new BfgsBMinimizer(1e-7, 1e-7, 1e-7, 5000);
+            var result = solver.FindMinimum(obj,
+                Vector<double>.Build.DenseOfArray(lower),
+                Vector<double>.Build.DenseOfArray(upper),
+                Vector<double>.Build.DenseOfArray(init));
+
+            var mp = result.MinimizingPoint.ToArray();
+            for (int i = 0; i < N; i++)
+            {
+                int b = i * 3;
+                double azRad = Math.Atan2(mp[b], mp[b + 1]);
+                double elRad = Math.Asin(Math.Clamp(mp[b + 2], -1.0, 1.0));
+                double azDeg = azRad * 180.0 / Math.PI;
+                if (azDeg < 0) azDeg += 360.0;
+
+                var n = or.Nodes.GetOrAdd(directionalNodeIds[i]);
+                n.Azimuth = Math.Round(azDeg / 45.0) * 45.0 % 360.0;
+                n.Elevation = Math.Round(elRad * 180.0 / Math.PI / 45.0) * 45.0;
+            }
+
+            Log.Debug("{Name} Phase 2 (antenna) completed with error: {Error}", Name, result.FunctionInfoAtMinimum.Value);
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Error in {Name} Phase 2: {Message}", Name, ex.Message);
+        }
+    }
+
+    private Dictionary<Measure, double> PreCalculateWeights(List<Measure> allMeasures)
+    {
+        var measureWeights = new Dictionary<Measure, double>();
+        double totalWeight = 0;
+        foreach (var m in allMeasures)
+        {
+            double w = m.RssiVar > 0 ? 1.0 / Math.Max(m.RssiVar.Value, 0.1) : 1.0;
+            measureWeights[m] = w;
+            totalWeight += w;
+        }
+        if (totalWeight > 0)
+            foreach (var m in allMeasures)
+                measureWeights[m] = measureWeights[m] / totalWeight * allMeasures.Count;
+        return measureWeights;
+    }
+
+    private static double ComputeLinkGainDb(double[] x, Dictionary<string, int> idxMap, Measure measure)
+    {
+        double dx = measure.Tx.Location.X - measure.Rx.Location.X;
+        double dy = measure.Tx.Location.Y - measure.Rx.Location.Y;
+        double dz = measure.Tx.Location.Z - measure.Rx.Location.Z;
+        return ComputeNodeGainDb(x, idxMap, measure.Rx, dx, dy, dz)
+             + ComputeNodeGainDb(x, idxMap, measure.Tx, -dx, -dy, -dz);
+    }
+
+    private static double ComputeNodeGainDb(double[] x, Dictionary<string, int> idxMap, OptNode node, double dx, double dy, double dz)
+    {
+        if (!node.IsNode || !node.HasDirectionalAntenna || !idxMap.TryGetValue(node.Id, out var idx))
+            return 0.0;
+
+        double sinAz = x[idx], cosAz = x[idx + 1], sinEl = x[idx + 2];
+        double azNorm = Math.Sqrt(sinAz * sinAz + cosAz * cosAz);
+        if (azNorm < 1e-9) { sinAz = 0.0; cosAz = 1.0; }
+        else { sinAz /= azNorm; cosAz /= azNorm; }
+        double cosEl = Math.Sqrt(Math.Max(1.0 - sinEl * sinEl, 0.0));
+
+        return MathUtils.ComputeGainDb(
+            sinAz * cosEl, cosAz * cosEl, sinEl, dx, dy, dz,
+            10.0 * Math.Log10(node.GMax), node.PatternExponent, node.BackLossDb);
     }
 }

--- a/src/Optimizers/OptimizationRunner.cs
+++ b/src/Optimizers/OptimizationRunner.cs
@@ -54,6 +54,7 @@ internal class OptimizationRunner : BackgroundService
         {
             "global_absorption" => new List<IOptimizer> { new GlobalAbsorptionRxTxOptimizer(_state) },
             "per_node_absorption" => new List<IOptimizer> { new PerNodeAbsorptionRxTx(_state) },
+            "combined" => new List<IOptimizer> { new CombinedOptimizer(_state) },
             _ => new List<IOptimizer>
             {
                 new RxAdjRssiOptimizer(_state),
@@ -141,8 +142,8 @@ internal class OptimizationRunner : BackgroundService
                             optimizer.Name, composite, bestScore, corr, rmse);
 
                         foreach (var (id, result) in results.Nodes)
-                            Log.Debug("Rejected {0,-20}: Absorption={1:0.00}, RxAdj={2:00}, TxAdj={3:00}, Error={4}",
-                                id, result.Absorption, result.RxAdjRssi, result.TxRefRssi, result.Error);
+                            Log.Debug("Rejected {0,-20}: Absorption={1:0.00}, RxAdj={2:00}, TxAdj={3:00}, Az={4}, El={5}, Error={6}",
+                                id, result.Absorption, result.RxAdjRssi, result.TxRefRssi, result.Azimuth?.ToString("0.0") ?? "n/a", result.Elevation?.ToString("0.0") ?? "n/a", result.Error);
                         continue;
                     }
 
@@ -153,13 +154,15 @@ internal class OptimizationRunner : BackgroundService
 
                     foreach (var (id, result) in results.Nodes)
                     {
-                        Log.Information("Applied {0,-20}: Absorption={1:0.00}, RxAdj={2:00}, TxAdj={3:00}, Error={4}",
-                            id, result.Absorption, result.RxAdjRssi, result.TxRefRssi, result.Error);
+                        Log.Information("Applied {0,-20}: Absorption={1:0.00}, RxAdj={2:00}, TxAdj={3:00}, Az={4}, El={5}, Error={6}",
+                            id, result.Absorption, result.RxAdjRssi, result.TxRefRssi, result.Azimuth?.ToString("0.0") ?? "n/a", result.Elevation?.ToString("0.0") ?? "n/a", result.Error);
 
                         var nodeSettings = _nsd.Get(id);
                         if (result.Absorption != null) nodeSettings.Calibration.Absorption = result.Absorption;
                         if (result.RxAdjRssi != null) nodeSettings.Calibration.RxAdjRssi = (int?)Math.Round(result.RxAdjRssi.Value);
                         if (result.TxRefRssi != null) nodeSettings.Calibration.TxRefRssi = (int?)Math.Round(result.TxRefRssi.Value);
+                        if (result.Azimuth != null) nodeSettings.Calibration.Azimuth = result.Azimuth;
+                        if (result.Elevation != null) nodeSettings.Calibration.Elevation = result.Elevation;
                         // Removed: nodeSettings.Calibration.Optimizer = optimizer.Name;
                         await _nsd.Set(id, nodeSettings);
                     }

--- a/src/Optimizers/Step2Layout.cs
+++ b/src/Optimizers/Step2Layout.cs
@@ -1,0 +1,215 @@
+namespace ESPresense.Optimizers;
+
+/// <summary>
+/// Defines the 4N blocked parameter-vector layout used in the Step-2 antenna-aware
+/// absorption / pointing optimisation.
+///
+/// For N nodes the flat vector is laid out as four contiguous blocks:
+///
+///   [ abs_0 … abs_{N-1} | sinAz_0 … sinAz_{N-1} | cosAz_0 … cosAz_{N-1} | sinEl_0 … sinEl_{N-1} ]
+///     ^--- block 0 ----^   ^------- block 1 ------^   ^------- block 2 ------^   ^-- block 3 --^
+///
+/// All downstream code that constructs, reads, or differentiates the Step-2 vector
+/// MUST use the helpers on this class so that the mapping is a single source of truth.
+/// </summary>
+public static class Step2Layout
+{
+    // -----------------------------------------------------------------------
+    // Block ordinals (zero-based block index)
+    // -----------------------------------------------------------------------
+
+    /// <summary>Block index for per-node path-loss absorption coefficients.</summary>
+    public const int AbsBlock = 0;
+
+    /// <summary>Block index for sin(azimuth) of each node's antenna boresight.</summary>
+    public const int SinAzBlock = 1;
+
+    /// <summary>Block index for cos(azimuth) of each node's antenna boresight.</summary>
+    public const int CosAzBlock = 2;
+
+    /// <summary>Block index for sin(elevation) of each node's antenna boresight.</summary>
+    public const int SinElBlock = 3;
+
+    /// <summary>Total number of parameter blocks.</summary>
+    public const int BlockCount = 4;
+
+    // -----------------------------------------------------------------------
+    // Total vector length
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns the total length of the Step-2 parameter vector for <paramref name="nodeCount"/> nodes.
+    /// </summary>
+    public static int VectorLength(int nodeCount) => VectorLength(nodeCount, nodeCount);
+
+    /// <summary>
+    /// Returns the total length of the Step-2 parameter vector when absorption is optimized
+    /// for <paramref name="absorptionCount"/> ids and pointing is optimized only for
+    /// <paramref name="directionalCount"/> directional ids.
+    /// </summary>
+    public static int VectorLength(int absorptionCount, int directionalCount) => absorptionCount + (3 * directionalCount);
+
+    // -----------------------------------------------------------------------
+    // Block start offsets
+    // -----------------------------------------------------------------------
+
+    /// <summary>Index of the first element of the absorption block.</summary>
+    public static int AbsOffset(int nodeCount) => 0;
+
+    /// <summary>Index of the first element of the sinAz block.</summary>
+    public static int SinAzOffset(int nodeCount) => nodeCount;
+
+    /// <summary>Index of the first element of the sinAz block.</summary>
+    public static int SinAzOffset(int absorptionCount, int directionalCount) => absorptionCount;
+
+    /// <summary>Index of the first element of the cosAz block.</summary>
+    public static int CosAzOffset(int nodeCount) => 2 * nodeCount;
+
+    /// <summary>Index of the first element of the cosAz block.</summary>
+    public static int CosAzOffset(int absorptionCount, int directionalCount) => absorptionCount + directionalCount;
+
+    /// <summary>Index of the first element of the sinEl block.</summary>
+    public static int SinElOffset(int nodeCount) => 3 * nodeCount;
+
+    /// <summary>Index of the first element of the sinEl block.</summary>
+    public static int SinElOffset(int absorptionCount, int directionalCount) => absorptionCount + (2 * directionalCount);
+
+    // -----------------------------------------------------------------------
+    // Per-node element indices
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Returns the flat-vector index for the absorption coefficient of node
+    /// <paramref name="nodeIndex"/> within a vector sized for <paramref name="nodeCount"/> nodes.
+    /// </summary>
+    public static int AbsIndex(int nodeIndex, int nodeCount) => AbsOffset(nodeCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for sin(azimuth) of node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int SinAzIndex(int nodeIndex, int nodeCount) => SinAzOffset(nodeCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for sin(azimuth) of directional node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int SinAzIndex(int nodeIndex, int absorptionCount, int directionalCount) => SinAzOffset(absorptionCount, directionalCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for cos(azimuth) of node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int CosAzIndex(int nodeIndex, int nodeCount) => CosAzOffset(nodeCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for cos(azimuth) of directional node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int CosAzIndex(int nodeIndex, int absorptionCount, int directionalCount) => CosAzOffset(absorptionCount, directionalCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for sin(elevation) of node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int SinElIndex(int nodeIndex, int nodeCount) => SinElOffset(nodeCount) + nodeIndex;
+
+    /// <summary>
+    /// Returns the flat-vector index for sin(elevation) of directional node <paramref name="nodeIndex"/>.
+    /// </summary>
+    public static int SinElIndex(int nodeIndex, int absorptionCount, int directionalCount) => SinElOffset(absorptionCount, directionalCount) + nodeIndex;
+
+    // -----------------------------------------------------------------------
+    // Convenience: extract per-node values from a populated vector
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Decodes the reparameterised azimuth for node <paramref name="i"/> from the flat vector.
+    /// Returns azimuth in radians via atan2(sinAz, cosAz).
+    /// </summary>
+    public static double GetAzimuthRad(IReadOnlyList<double> x, int i, int nodeCount)
+    {
+        return Math.Atan2(x[SinAzIndex(i, nodeCount)], x[CosAzIndex(i, nodeCount)]);
+    }
+
+    /// <summary>
+    /// Decodes the reparameterised azimuth for directional node <paramref name="i"/> from the flat vector.
+    /// Returns azimuth in radians via atan2(sinAz, cosAz).
+    /// </summary>
+    public static double GetAzimuthRad(IReadOnlyList<double> x, int i, int absorptionCount, int directionalCount)
+    {
+        return Math.Atan2(x[SinAzIndex(i, absorptionCount, directionalCount)], x[CosAzIndex(i, absorptionCount, directionalCount)]);
+    }
+
+    /// <summary>
+    /// Decodes the reparameterised elevation for node <paramref name="i"/> from the flat vector.
+    /// Returns elevation in radians via asin(clamp(sinEl, -1, 1)).
+    /// </summary>
+    public static double GetElevationRad(IReadOnlyList<double> x, int i, int nodeCount)
+    {
+        return Math.Asin(Math.Clamp(x[SinElIndex(i, nodeCount)], -1.0, 1.0));
+    }
+
+    /// <summary>
+    /// Decodes the reparameterised elevation for directional node <paramref name="i"/> from the flat vector.
+    /// Returns elevation in radians via asin(clamp(sinEl, -1, 1)).
+    /// </summary>
+    public static double GetElevationRad(IReadOnlyList<double> x, int i, int absorptionCount, int directionalCount)
+    {
+        return Math.Asin(Math.Clamp(x[SinElIndex(i, absorptionCount, directionalCount)], -1.0, 1.0));
+    }
+
+    /// <summary>
+    /// Returns the unit-circle regularisation penalty for node <paramref name="i"/>:
+    ///   0.1 * (sinAz² + cosAz² - 1)²
+    /// This drives sinAz and cosAz toward the unit circle without enforcing a hard constraint.
+    /// </summary>
+    public static double UnitCirclePenalty(IReadOnlyList<double> x, int i, int nodeCount)
+    {
+        double sa = x[SinAzIndex(i, nodeCount)];
+        double ca = x[CosAzIndex(i, nodeCount)];
+        double dev = sa * sa + ca * ca - 1.0;
+        return 0.1 * dev * dev;
+    }
+
+    /// <summary>
+    /// Returns the unit-circle regularisation penalty for directional node <paramref name="i"/>.
+    /// </summary>
+    public static double UnitCirclePenalty(IReadOnlyList<double> x, int i, int absorptionCount, int directionalCount)
+    {
+        double sa = x[SinAzIndex(i, absorptionCount, directionalCount)];
+        double ca = x[CosAzIndex(i, absorptionCount, directionalCount)];
+        double dev = sa * sa + ca * ca - 1.0;
+        return 0.1 * dev * dev;
+    }
+
+    // -----------------------------------------------------------------------
+    // Convenience: build initial-guess slices
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Populates the absorption block of <paramref name="x"/> (assumed length
+    /// <see cref="VectorLength"/>) from <paramref name="absorptions"/>.
+    /// </summary>
+    public static void SetAbsorptions(double[] x, IReadOnlyList<double> absorptions, int nodeCount)
+    {
+        for (int i = 0; i < nodeCount; i++)
+            x[AbsIndex(i, nodeCount)] = absorptions[i];
+    }
+
+    /// <summary>
+    /// Populates the sinAz and cosAz blocks from an array of azimuth angles in radians.
+    /// </summary>
+    public static void SetAzimuths(double[] x, IReadOnlyList<double> azimuthsRad, int nodeCount)
+    {
+        for (int i = 0; i < nodeCount; i++)
+        {
+            x[SinAzIndex(i, nodeCount)] = Math.Sin(azimuthsRad[i]);
+            x[CosAzIndex(i, nodeCount)] = Math.Cos(azimuthsRad[i]);
+        }
+    }
+
+    /// <summary>
+    /// Populates the sinEl block from an array of elevation angles in radians.
+    /// </summary>
+    public static void SetElevations(double[] x, IReadOnlyList<double> elevationsRad, int nodeCount)
+    {
+        for (int i = 0; i < nodeCount; i++)
+            x[SinElIndex(i, nodeCount)] = Math.Sin(elevationsRad[i]);
+    }
+}

--- a/src/Services/DistanceCalculator.cs
+++ b/src/Services/DistanceCalculator.cs
@@ -1,0 +1,74 @@
+namespace ESPresense.Services;
+
+using ESPresense.Models;
+
+/// <summary>
+/// Computes BLE distance from RSSI using calibration data (absorption, rxAdj, txAdj)
+/// and antenna gain correction. Replaces firmware-reported distances.
+/// </summary>
+public class DistanceCalculator
+{
+    private readonly NodeSettingsStore _nodeSettings;
+    private readonly State _state;
+
+    public DistanceCalculator(NodeSettingsStore nodeSettings, State state)
+    {
+        _nodeSettings = nodeSettings;
+        _state = state;
+    }
+
+    /// <summary>
+    /// Compute distance from RSSI for a node-to-node measurement.
+    /// Applies antenna gain correction for both Tx and Rx nodes if configured.
+    /// </summary>
+    public double ComputeNodeDistance(Node txNode, Node rxNode, double rssi, double refRssi)
+    {
+        var rxNs = _nodeSettings.Get(rxNode.Id);
+        var txNs = _nodeSettings.Get(txNode.Id);
+        double absorption = rxNs.Calibration?.Absorption ?? 3.0;
+
+        // Compute antenna gain for both nodes
+        double gainDb = 0.0;
+        if (txNode.HasLocation && rxNode.HasLocation)
+        {
+            double dx = txNode.Location.X - rxNode.Location.X;
+            double dy = txNode.Location.Y - rxNode.Location.Y;
+            double dz = txNode.Location.Z - rxNode.Location.Z;
+
+            gainDb += ComputeNodeGain(rxNode, rxNs, dx, dy, dz);
+            gainDb += ComputeNodeGain(txNode, txNs, -dx, -dy, -dz);
+        }
+
+        return ComputeDistance(rssi, refRssi, absorption, gainDb);
+    }
+
+    /// <summary>
+    /// Distance from RSSI using log-distance path loss model.
+    /// rxAdj/txRef are NOT included — those are RSSI-domain corrections
+    /// used by the optimizer, not the distance formula.
+    /// </summary>
+    private static double ComputeDistance(double rssi, double refRssi, double absorption, double gainDb)
+    {
+        if (absorption == 0.0) absorption = 3.0;
+        double dist = Math.Pow(10.0, (refRssi + gainDb - rssi) / (10.0 * absorption));
+        return double.IsNaN(dist) || double.IsInfinity(dist) ? 0.0 : dist;
+    }
+
+    private double ComputeNodeGain(Node node, NodeSettings ns, double dx, double dy, double dz)
+    {
+        var antenna = _state.Config?.ResolveAntenna(node.AntennaProfile);
+        if (antenna == null) return 0.0;
+
+        double azDeg = ns.Calibration?.Azimuth ?? 0.0;
+        double elDeg = ns.Calibration?.Elevation ?? 0.0;
+        double azRad = azDeg * Math.PI / 180.0;
+        double elRad = elDeg * Math.PI / 180.0;
+
+        double px = Math.Sin(azRad) * Math.Cos(elRad);
+        double py = Math.Cos(azRad) * Math.Cos(elRad);
+        double pz = Math.Sin(elRad);
+
+        return Utils.MathUtils.ComputeGainDb(px, py, pz, dx, dy, dz,
+            antenna.GMaxDb, antenna.PatternExponent, antenna.BackLoss);
+    }
+}

--- a/src/Utils/MathUtils.cs
+++ b/src/Utils/MathUtils.cs
@@ -214,5 +214,51 @@ namespace ESPresense.Utils
         }
 
         private readonly record struct Block(int Start, int End, double Weight, double Value);
+
+        /// <summary>
+        /// Computes directional antenna gain in dB using a simplified antenna radiation model.
+        /// </summary>
+        /// <param name="px">Antenna pointing vector X (sin(az)*cos(el))</param>
+        /// <param name="py">Antenna pointing vector Y (cos(az)*cos(el))</param>
+        /// <param name="pz">Antenna pointing vector Z (sin(el))</param>
+        /// <param name="dx">Path vector X (from Rx to Tx)</param>
+        /// <param name="dy">Path vector Y (from Rx to Tx)</param>
+        /// <param name="dz">Path vector Z (from Rx to Tx)</param>
+        /// <param name="gMaxDb">Maximum gain in dB (at broadside)</param>
+        /// <param name="patternExponent">Pattern exponent controlling front/back gain ratio</param>
+        /// <param name="backLossDb">Back lobe loss in dB</param>
+        /// <returns>Antenna gain contribution in dB</returns>
+        public static double ComputeGainDb(double px, double py, double pz, double dx, double dy, double dz, double gMaxDb, double patternExponent, double backLossDb)
+        {
+            double len = Math.Sqrt(dx * dx + dy * dy + dz * dz);
+            if (len < 1e-9) return gMaxDb; // co-located
+
+            // cosTheta = dot product of normalized path vector and pointing vector
+            double cosTheta = (px * dx + py * dy + pz * dz) / len;
+
+            // Front hemisphere: cosTheta > 0
+            // cosTheta = 1 (head-on) → gain = GMax
+            // cosTheta = 0 (edge-on) → gain = GMax - 3
+            // Back hemisphere: cosTheta < 0 → apply backLoss penalty
+            if (cosTheta >= 0)
+            {
+                // Front: gain rolls off smoothly from GMax at cosTheta=1 to GMax-3 at cosTheta=0
+                double gainDb = gMaxDb - 3.0 * (1.0 - cosTheta);
+                // Apply pattern shaping: higher patternExponent = sharper front beam
+                if (patternExponent != 0)
+                {
+                    // Widen the beam by reducing the effective rolloff
+                    double rolloff = 3.0 * Math.Pow(cosTheta, patternExponent + 1.0);
+                    gainDb = gMaxDb - rolloff;
+                }
+                return gainDb;
+            }
+            else
+            {
+                // Back: apply back loss (more negative cosTheta = more loss)
+                double gainDb = gMaxDb - 3.0 * (1.0 - cosTheta) - backLossDb;
+                return Math.Min(gainDb, gMaxDb - backLossDb);
+            }
+        }
     }
 }

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -242,14 +242,50 @@ floors:
           - [5,17.1]
           - [1.3,17.1]
 
+# Antenna profiles (optional, extends/overrides built-ins)
+# Built-in profiles: pcb_ifa, dev_board, 3d_pifa, 3d_pifa_pro, external_dipole, switchbot_cramped
+antennas:
+  pcb_ifa:
+    # ESP-WROOM-32E module, clean custom boards
+    g_max_db: 3.4
+    pattern_exponent: 0.28
+    back_loss: 14.3
+
+  dev_board:
+    # ESP32 dev boards (DevKitC, NodeMCU, etc.)
+    g_max_db: 2.5
+    pattern_exponent: 0.25
+    back_loss: 12
+
+  3d_pifa:
+    # M5Atom standard
+    g_max_db: 2.0
+    pattern_exponent: 0.03
+    back_loss: 5.5
+
+  3d_pifa_pro:
+    # M5Atom PRO-OB-440 (the "enhanced" one)
+    g_max_db: 2.0
+    pattern_exponent: 0.03
+    back_loss: 5.5
+
+  external_dipole:
+    # External 2.4 GHz dipole (rubber ducky style)
+    g_max_db: 4.0
+    pattern_exponent: 0.2
+    back_loss: 2
+
+
 # Locations of espresense nodes in meters
 nodes:
   - name: Master
     point: [3.4, 10.4, 3.4]
     floors: ["second"]
+    antenna: pcb_ifa         # references an antenna profile by name
   - name: Bathroom
     point: [0.15, 8.6, 4]
     floors: ["second"]
+    antenna: 3d_pifa         # M5Atom standard
   - name: Upstairs Hallway
     point: [10.4, 6.4, 3.4]
     floors: ["second"]

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -13,7 +13,7 @@
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
-		"@eslint/js": "^9.39.4",
+		"@eslint/js": "^9.39.2",
 		"@floating-ui/dom": "^1.7.5",
 		"@playwright/test": "^1.58.2",
 		"@skeletonlabs/floating-ui-svelte": "^0.3.9",
@@ -24,7 +24,7 @@
 		"@sveltejs/kit": "^2.53.4",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@tailwindcss/forms": "^0.5.11",
-		"@tailwindcss/vite": "^4.2.1",
+		"@tailwindcss/vite": "^4.1.18",
 		"@testing-library/svelte": "^5.3.1",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/d3": "^7.4.3",
@@ -46,10 +46,10 @@
 		"layercake": "^10.0.1",
 		"ol": "^10.8.0",
 		"prettier": "^3.8.1",
-		"prettier-plugin-svelte": "^3.5.1",
+		"prettier-plugin-svelte": "^3.4.1",
 		"s-ago": "^2.2.0",
 		"svelte": "^5.53.8",
-		"svelte-check": "^4.4.5",
+		"svelte-check": "^4.4.4",
 		"svelte-eslint-parser": "^1.4.1",
 		"svelte-table": "^0.6.5",
 		"tailwindcss": "^4.2.1",
@@ -59,7 +59,7 @@
 		"typescript-eslint": "^8.56.1",
 		"vite": "^7.3.1",
 		"vite-plugin-devtools-json": "^1.0.0",
-		"vitest": "^4.1.0"
+		"vitest": "^4.0.18"
 	},
 	"type": "module"
 }

--- a/src/ui/pnpm-lock.yaml
+++ b/src/ui/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@eslint/js':
-        specifier: ^9.39.4
+        specifier: ^9.39.2
         version: 9.39.4
       '@floating-ui/dom':
         specifier: ^1.7.5
@@ -42,7 +42,7 @@ importers:
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.1)
       '@tailwindcss/vite':
-        specifier: ^4.2.1
+        specifier: ^4.1.18
         version: 4.2.1(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.1))
       '@testing-library/svelte':
         specifier: ^5.3.1
@@ -108,7 +108,7 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       prettier-plugin-svelte:
-        specifier: ^3.5.1
+        specifier: ^3.4.1
         version: 3.5.1(prettier@3.8.1)(svelte@5.53.8)
       s-ago:
         specifier: ^2.2.0
@@ -117,7 +117,7 @@ importers:
         specifier: ^5.53.8
         version: 5.53.8
       svelte-check:
-        specifier: ^4.4.5
+        specifier: ^4.4.4
         version: 4.4.5(picomatch@4.0.3)(svelte@5.53.8)(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: ^1.4.1
@@ -147,7 +147,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.1))
       vitest:
-        specifier: ^4.1.0
+        specifier: ^4.0.18
         version: 4.1.0(@types/node@25.2.3)(jsdom@28.1.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.1))
 
 packages:
@@ -511,66 +511,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -716,24 +729,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -1852,24 +1869,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}

--- a/src/ui/src/lib/DeviceCalibrationManager.svelte
+++ b/src/ui/src/lib/DeviceCalibrationManager.svelte
@@ -8,18 +8,17 @@
 	import type { Device } from '$lib/types';
 	import ago from 's-ago';
 
-	$: filteredDevices =
-		$devices?.filter((device) => {
-			// Check if device is active based on lastSeen and timeout
-			if (device.lastSeen == null) return false;
-			const timeout = device.timeout !== null && device.timeout !== undefined ? device.timeout : 30000;
-			return new Date().getTime() - new Date(device.lastSeen).getTime() < timeout;
-		}) || [];
+	$: filteredDevices = $devices?.filter(device => {
+		// Check if device is active based on lastSeen and timeout
+		if (device.lastSeen == null) return false;
+		const timeout = device.timeout !== null && device.timeout !== undefined ? device.timeout : 30000;
+		return new Date().getTime() - new Date(device.lastSeen).getTime() < timeout;
+	}) || [];
 
 	$: calibrationStats = {
 		total: filteredDevices.length,
-		calibrated: filteredDevices.filter((d) => d['rssi@1m'] != null).length,
-		needsCalibration: filteredDevices.filter((d) => d['rssi@1m'] == null).length
+		calibrated: filteredDevices.filter(d => d['rssi@1m'] != null).length,
+		needsCalibration: filteredDevices.filter(d => d['rssi@1m'] == null).length
 	};
 
 	function isDeviceActive(device: Device): boolean {
@@ -39,7 +38,7 @@
 
 	function displayRoomFloor(d: Device): string {
 		const base = baseRoomFloor(d);
-		return (d.isAnchored ?? false) ? `${base} 📍` : base;
+		return d.isAnchored ? `${base} 📍` : base;
 	}
 
 	const columns = [
@@ -137,9 +136,16 @@
 		<div class="card">
 			<header class="text-lg font-semibold mb-4">Device Calibration</header>
 			{#if filteredDevices.length > 0}
-				<DataTable {columns} rows={filteredDevices} classNameTable="table table-compact" onclickRow={onRowClick} />
+				<DataTable
+					{columns}
+					rows={filteredDevices}
+					classNameTable="table table-compact"
+					onclickRow={onRowClick}
+				/>
 			{:else}
-				<div class="text-center py-8 text-surface-600-400">No active devices found</div>
+				<div class="text-center py-8 text-surface-600-400">
+					No active devices found
+				</div>
 			{/if}
 		</div>
 	</div>

--- a/src/ui/src/lib/DeviceMarker.svelte
+++ b/src/ui/src/lib/DeviceMarker.svelte
@@ -43,12 +43,27 @@
 
 {#if visible && d.confidence > 1 && d.location}
 	<g in:fade={{ duration: 1000 }} out:fade={{ duration: 1000 }}>
-		{#if d.isAnchored ?? false}
-			<path role="none" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z" transform="translate({$xScale($x) - 12}, {$yScale($y) - 24})" fill={$c} stroke={d.id == hovered ? 'black' : 'white'} stroke-width={$s} onmouseover={() => hover(d)} onfocus={() => select(d)} onmouseout={() => hover(null)} onblur={() => unselect()} />
-			<circle cx={$xScale($x)} cy={$yScale($y) - 15} r={3} fill="white" pointer-events="none" />
-		{:else}
-			<circle role="none" cx={$xScale($x)} cy={$yScale($y)} fill={$c} stroke={d.id == hovered ? 'black' : 'white'} stroke-width={$s} r={$r} onmouseover={() => hover(d)} onfocus={() => select(d)} onmouseout={() => hover(null)} onblur={() => unselect()} />
-		{/if}
+		<circle
+			role="none"
+			cx={$xScale($x)}
+			cy={$yScale($y)}
+			fill={$c}
+			stroke={d.id == hovered ? 'black' : 'white'}
+			stroke-width={$s}
+			r={$r}
+			onmouseover={() => {
+				hover(d);
+			}}
+			onfocus={() => {
+				select(d);
+			}}
+			onmouseout={() => {
+				hover(null);
+			}}
+			onblur={() => {
+				unselect();
+			}}
+		/>
 		<text x={$xScale($x) + 7} y={$yScale($y) + 3} fill="white" font-size="10px">{d.name ?? d.id}</text>
 	</g>
 {/if}

--- a/src/ui/src/lib/NodeCalibrationMatrix.svelte
+++ b/src/ui/src/lib/NodeCalibrationMatrix.svelte
@@ -4,16 +4,10 @@
 	import { getToastStore } from '$lib/toast/toastStore';
 	import { showConfirm } from '$lib/modal/modalStore';
 	import { tooltip } from '$lib/tooltip';
-	import SlideToggle from '$lib/SlideToggle.svelte';
-	import { onMount } from 'svelte';
 
 	enum DataPoint {
 		ErrorPercent = 0,
-		ErrorMeters = 1,
-		Absorption = 2,
-		RxRssiAdj = 3,
-		TxRssiRef = 4,
-		VarianceMeters = 5
+		ErrorMeters = 1
 	}
 
 	function coloring(percent: number | null): string {
@@ -32,28 +26,17 @@
 	}
 
 	function value(n1: any, data_point: number) {
+		if (!n1) return null;
 		if (data_point === DataPoint.ErrorPercent) {
-			return n1 ? Number(Math.round(n1.percent * 100)) + '%' : null;
-		} else if (data_point >= 1 && data_point <= 5) {
-			let num;
-			switch (data_point) {
-				case DataPoint.ErrorMeters:
-					num = n1?.diff;
-					break;
-				case DataPoint.Absorption:
-					num = n1?.absorption;
-					break;
-				case DataPoint.RxRssiAdj:
-					num = n1?.rx_adj_rssi;
-					break;
-				case DataPoint.TxRssiRef:
-					num = n1?.tx_ref_rssi;
-					break;
-				case DataPoint.VarianceMeters:
-					num = n1?.var;
-					break;
+			return Number(Math.round(n1.percent * 100)) + '%';
+		} else {
+			const diff = n1?.diff;
+			if (diff == null) return 'n/a';
+			const base = diff.toFixed(1);
+			if (n1?.var != null) {
+				return `${base}\u00A0\u00B1${Math.sqrt(n1.var).toFixed(1)}`;
 			}
-			return num !== null && num !== undefined ? Number(num.toPrecision(3)) : 'n/a';
+			return base;
 		}
 	}
 
@@ -80,57 +63,9 @@
 	}
 
 	let data_point: DataPoint = 0;
+	let nodeView: 'matrix' | 'settings' = 'matrix';
 
 	const toastStore = getToastStore();
-	let autoOptimization = false;
-	let autoOptimizationLoaded = false;
-	let autoOptimizationBusy = false;
-
-	async function fetchAutoOptimizationState() {
-		try {
-			const response = await fetch(resolve('/api/state/calibration/auto-optimize'));
-			if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-			const data = await response.json();
-			autoOptimization = !!data.autoOptimize;
-		} catch (error) {
-			console.error('Error fetching auto-optimization state:', error);
-			toastStore.trigger({
-				message: error instanceof Error ? error.message : 'Failed to load auto-optimization state',
-				background: 'preset-filled-error-500'
-			});
-		} finally {
-			autoOptimizationLoaded = true;
-		}
-	}
-
-	async function toggleAutoOptimization() {
-		if (!autoOptimizationLoaded || autoOptimizationBusy) return;
-		autoOptimizationBusy = true;
-		const desiredState = autoOptimization;
-
-		try {
-			const response = await fetch(resolve('/api/state/calibration/auto-optimize'), {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify(desiredState)
-			});
-
-			if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-			const data = await response.json();
-			autoOptimization = !!data.autoOptimize;
-		} catch (error) {
-			console.error('Error toggling auto-optimization:', error);
-			autoOptimization = !desiredState;
-			toastStore.trigger({
-				message: error instanceof Error ? error.message : 'Failed to toggle auto-optimization',
-				background: 'preset-filled-error-500'
-			});
-		} finally {
-			autoOptimizationBusy = false;
-		}
-	}
 
 	async function resetCalibration() {
 		const confirmed = await showConfirm({
@@ -159,11 +94,7 @@
 			});
 		}
 	}
-
-	onMount(fetchAutoOptimizationState);
 </script>
-
-<!-- Retrigger CI on $(date) -->
 
 <div class="h-full overflow-y-auto">
 	<div class="w-full px-4 py-2">
@@ -197,7 +128,49 @@
 		</div>
 		{/if}
 
-		{#if $calibration?.matrix}
+		<div class="flex justify-center mb-4"><div class="flex bg-slate-600 rounded-full p-1">
+			<button class="px-4 py-1 rounded-full text-sm font-medium transition-colors {nodeView === 'matrix' ? 'bg-emerald-400 text-black' : 'text-white hover:bg-slate-500'}" onclick={() => (nodeView = 'matrix')}>
+				Matrix
+			</button>
+			<button class="px-4 py-1 rounded-full text-sm font-medium transition-colors {nodeView === 'settings' ? 'bg-emerald-400 text-black' : 'text-white hover:bg-slate-500'}" onclick={() => (nodeView = 'settings')}>
+				Settings
+			</button>
+		</div></div>
+
+		{#if nodeView === 'settings' && $calibration?.nodes && Object.keys($calibration.nodes).length > 0}
+		<div class="card mb-4">
+			<div class="overflow-x-auto">
+				<table class="table table-compact">
+					<thead>
+						<tr>
+							<th class="text-left" style="color: oklch(1 0 none);">Node</th>
+							<th class="text-left" style="color: oklch(1 0 none);">Antenna</th>
+							<th class="text-right" style="color: oklch(1 0 none);">Azimuth</th>
+							<th class="text-right" style="color: oklch(1 0 none);">Elevation</th>
+							<th class="text-right" style="color: oklch(1 0 none);">Absorption</th>
+							<th class="text-right" style="color: oklch(1 0 none);">Rx Adj RSSI</th>
+							<th class="text-right" style="color: oklch(1 0 none);">Tx Ref RSSI</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each Object.entries($calibration.nodes).sort((a, b) => a[0].localeCompare(b[0])) as [name, node] (name)}
+							<tr>
+								<td class="font-medium">{name}</td>
+								<td class="text-left">{#if node.antenna}<span class="badge preset-filled-surface-500 text-xs">{node.antenna}</span>{:else}<span class="text-surface-400">-</span>{/if}</td>
+								<td class="text-right tabular-nums">{node.azimuth != null ? node.azimuth.toFixed(1) + '°' : '-'}</td>
+								<td class="text-right tabular-nums">{node.elevation != null ? node.elevation.toFixed(1) + '°' : '-'}</td>
+								<td class="text-right tabular-nums">{node.absorption != null ? node.absorption.toFixed(2) : '-'}</td>
+								<td class="text-right tabular-nums">{node.rxAdjRssi != null ? node.rxAdjRssi.toFixed(0) : '-'}</td>
+								<td class="text-right tabular-nums">{node.txRefRssi != null ? node.txRefRssi.toFixed(0) : '-'}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+		{/if}
+
+		{#if nodeView === 'matrix' && $calibration?.matrix}
 		<div class="card">
 			<header class="text-lg font-semibold mb-4">Node Calibration</header>
 			<div class="space-y-4">
@@ -206,22 +179,8 @@
 						<div class="flex flex-wrap items-center gap-2">
 							<button class="btn {data_point === 0 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 0)}>Error %</button>
 							<button class="btn {data_point === 1 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 1)}>Error (m)</button>
-							<button class="btn {data_point === 2 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 2)}>Absorption</button>
-							<button class="btn {data_point === 3 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 3)}>Rx Rssi Adj</button>
-							<button class="btn {data_point === 4 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 4)}>Tx Rssi Ref</button>
-							<button class="btn {data_point === 5 ? 'preset-filled-primary-500' : 'preset-ghost-surface-500'}" onclick={() => (data_point = 5)}>Variance (m)</button>
 						</div>
-						<div class="flex flex-wrap items-center gap-3">
-							<SlideToggle
-								name="auto-optimization"
-								bind:checked={autoOptimization}
-								disabled={!autoOptimizationLoaded || autoOptimizationBusy}
-								on:click={toggleAutoOptimization}
-							>
-								Auto Optimization
-							</SlideToggle>
-							<button class="btn preset-filled-warning-500" onclick={resetCalibration}> Reset Calibration </button>
-						</div>
+						<button class="btn preset-filled-warning-500" onclick={resetCalibration}> Reset Calibration </button>
 					</div>
 				</div>
 				<div class="overflow-x-auto">
@@ -241,7 +200,12 @@
 								<tr>
 									<td style="text-align: right; white-space: nowrap;">Tx: {id1}{#if isAnchored(id1)} 📍{/if}</td>
 									{#each rxColumns as id2 (id2)}
-										<td style="text-align: center; {coloring(n1[id2]?.percent)}" use:tooltip={n1[id2] ? `Map Distance ${Number(n1[id2].mapDistance?.toPrecision(3))} - Measured ${Number(n1[id2]?.distance?.toPrecision(3))} = Error ${Number(n1[id2]?.diff?.toPrecision(3))}` : 'No beacon Received in last 30 seconds'}
+										<td style="text-align: center; {coloring(n1[id2]?.percent)}" use:tooltip={n1[id2] ? [
+										`Map: ${Number(n1[id2].mapDistance?.toPrecision(3))}m  Measured: ${Number(n1[id2]?.distance?.toPrecision(3))}m`,
+										`Error: ${n1[id2]?.diff?.toFixed(1)}m${n1[id2]?.var != null ? ' \u00A0\u00B1' + Math.sqrt(n1[id2].var).toFixed(1) + 'm' : ''} (${Math.round(n1[id2].percent * 100)}%)`,
+										$calibration?.nodes?.[id1]?.antenna ? `Tx: ${$calibration.nodes[id1].antenna}` : '',
+										$calibration?.nodes?.[id2]?.antenna ? `Rx: ${$calibration.nodes[id2].antenna}` : ''
+									].filter(Boolean).join('\n') : 'No beacon received in last 30 seconds'}
 											>{#if n1[id2]}{value(n1[id2], data_point)}{/if}</td
 										>
 									{/each}
@@ -259,3 +223,4 @@
 		{/if}
 	</div>
 </div>
+

--- a/src/ui/src/lib/tooltip.ts
+++ b/src/ui/src/lib/tooltip.ts
@@ -22,10 +22,11 @@ export const tooltip: Action<HTMLElement, string> = (node, content) => {
 	function ensureTooltip() {
 		if (tooltipEl) return;
 		tooltipEl = document.createElement('div');
-		tooltipEl.className = 'card preset-filled-secondary-500 p-4';
+		tooltipEl.className = 'card preset-filled-secondary-500 p-4 text-sm';
 		tooltipEl.style.position = 'absolute';
 		tooltipEl.style.zIndex = '1000';
 		tooltipEl.style.pointerEvents = 'none';
+		tooltipEl.style.whiteSpace = 'pre-line';
 		tooltipEl.textContent = content ?? '';
 		// Set ARIA attributes for accessibility
 		tooltipEl.setAttribute('role', 'tooltip');

--- a/src/ui/src/lib/types.ts
+++ b/src/ui/src/lib/types.ts
@@ -116,6 +116,8 @@ export type NodeSetting = {
 		rxRefRssi: number | null;
 		rxAdjRssi: number | null;
 		txRefRssi: number | null;
+		azimuth: number | null;
+		elevation: number | null;
 	};
 };
 
@@ -205,6 +207,8 @@ export interface NodeCalibrationMatrix {
 			tx_ref_rssi?: number;
 			rx_adj_rssi?: number;
 			absorption?: number;
+			azimuth?: number;
+			elevation?: number;
 			mapDistance: number;
 			distance: number;
 			rssi: number;
@@ -221,8 +225,18 @@ export interface OptimizerState {
 	bestR?: number;
 }
 
+export interface NodeCalibration {
+	antenna?: string;
+	azimuth?: number;
+	elevation?: number;
+	absorption?: number;
+	rxAdjRssi?: number;
+	txRefRssi?: number;
+}
+
 export interface CalibrationResponse {
 	matrix: NodeCalibrationMatrix;
+	nodes?: Record<string, NodeCalibration>;
 	rmse?: number;
 	r?: number;
 	optimizerState?: OptimizerState;

--- a/src/ui/tests/tooltip.spec.ts
+++ b/src/ui/tests/tooltip.spec.ts
@@ -52,12 +52,12 @@ test.describe('Tooltip', () => {
 
 		// Verify tooltip content contains expected data
 		const tooltipText = await tooltip.textContent();
-		expect(tooltipText).toContain('Map Distance');
+		expect(tooltipText).toContain('Map:');
 		expect(tooltipText).toContain('4.57');
-		expect(tooltipText).toContain('Measured');
+		expect(tooltipText).toContain('Measured:');
 		expect(tooltipText).toContain('5.12');
-		expect(tooltipText).toContain('Error');
-		expect(tooltipText).toContain('0.556');
+		expect(tooltipText).toContain('Error:');
+		expect(tooltipText).toContain('0.6m');
 	});
 
 	test('hides tooltip when mouse leaves cell', async ({ page }) => {

--- a/tests/ESPresense.Companion.Simulation/CompareWeightings.cs
+++ b/tests/ESPresense.Companion.Simulation/CompareWeightings.cs
@@ -36,7 +36,7 @@ class CompareWeightings
         };
     }
 
-    private static (Config Config, Floor Floor, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore)
+    private static (Config Config, Floor Floor, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore, MockNodeSettingsStore NodeSettingsStore, MockDeviceSettingsStore DeviceSettingsStore)
         CreateSimulationContext(IWeighting? weighting)
     {
         var floor = new Floor();
@@ -63,12 +63,15 @@ class CompareWeightings
 
         var mockConfigLoader = new MockConfigLoader(config);
         var nodeTelemetryStore = new MockNodeTelemetryStore();
-        var state = new State(mockConfigLoader, nodeTelemetryStore);
+        var mockNss = new MockNodeSettingsStore();
+        var mockDss = new MockDeviceSettingsStore();
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss);
+        var state = new State(mockConfigLoader, nodeTelemetryStore, mockNss, lazyDss);
 
         var device = new Device("sim-device", "test-discovery", TimeSpan.FromSeconds(30));
         state.Devices[device.Id] = device;
 
-        return (config, floor, state, device, nodeTelemetryStore);
+        return (config, floor, state, device, nodeTelemetryStore, mockNss, mockDss);
     }
 
     public static void Run()
@@ -103,11 +106,11 @@ class CompareWeightings
         };
 
         // Locators to test (that support weighting)
-        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, ILocate> Factory)[]
+        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, NodeSettingsStore, DeviceSettingsStore, ILocate> Factory)[]
         {
-            ("BFGS", (d, f, s, nts) => new BfgsMultilateralizer(d, f, s)),
-            ("Nelder-Mead", (d, f, s, nts) => new NelderMeadMultilateralizer(d, f, s)),
-            ("MLE", (d, f, s, nts) => new MLEMultilateralizer(d, f, s)),
+            ("BFGS", (d, f, s, nts, nss, dss) => new BfgsMultilateralizer(d, f, s, nss, dss)),
+            ("Nelder-Mead", (d, f, s, nts, nss, dss) => new NelderMeadMultilateralizer(d, f, s, nss, dss)),
+            ("MLE", (d, f, s, nts, nss, dss) => new MLEMultilateralizer(d, f, s, nss, dss)),
         };
 
         int iterations = 200;
@@ -140,7 +143,9 @@ class CompareWeightings
                                 context.Device,
                                 context.Floor,
                                 context.State,
-                                context.NodeTelemetryStore);
+                                context.NodeTelemetryStore,
+                                context.NodeSettingsStore,
+                                context.DeviceSettingsStore);
                             var report = sim.RunMonteCarlo(
                                 iterations,
                                 locator,

--- a/tests/ESPresense.Companion.Simulation/MultiFloorConfidenceTest.cs
+++ b/tests/ESPresense.Companion.Simulation/MultiFloorConfidenceTest.cs
@@ -17,7 +17,7 @@ class MultiFloorConfidenceTest
     private const int BaseSeed = 54321;
     private const int IterationsPerScenario = 100;
     
-    private static (Config Config, List<Floor> Floors, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore)
+    private static (Config Config, List<Floor> Floors, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore, MockNodeSettingsStore NodeSettingsStore, MockDeviceSettingsStore DeviceSettingsStore)
         CreateMultiFloorContext()
     {
         var config = new Config
@@ -55,12 +55,15 @@ class MultiFloorConfidenceTest
 
         var mockConfigLoader = new MockConfigLoader(config);
         var nodeTelemetryStore = new MockNodeTelemetryStore();
-        var state = new State(mockConfigLoader, nodeTelemetryStore);
+        var nodeSettingsStore = new MockNodeSettingsStore();
+        var deviceSettingsStore = new MockDeviceSettingsStore();
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore);
+        var state = new State(mockConfigLoader, nodeTelemetryStore, nodeSettingsStore, lazyDss);
 
         var device = new Device("sim-device-multifloor", "test-discovery", TimeSpan.FromSeconds(30));
         state.Devices[device.Id] = device;
 
-        return (config, floors, state, device, nodeTelemetryStore);
+        return (config, floors, state, device, nodeTelemetryStore, nodeSettingsStore, deviceSettingsStore);
     }
 
     /// <summary>
@@ -235,6 +238,8 @@ class MultiFloorConfidenceTest
         var state = context.State;
         var device = context.Device;
         var nodeTelemetryStore = context.NodeTelemetryStore;
+        var nodeSettingsStore = context.NodeSettingsStore;
+        var deviceSettingsStore = context.DeviceSettingsStore;
 
         var basement = floors.First(f => f.Id == "basement");
         var first = floors.First(f => f.Id == "first");
@@ -258,13 +263,13 @@ class MultiFloorConfidenceTest
         Console.WriteLine($"\nIterations per scenario: {IterationsPerScenario}\n");
 
         // Locators to test
-        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, ILocate> Factory)[]
+        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, NodeSettingsStore, DeviceSettingsStore, ILocate> Factory)[]
         {
-            ("Gauss-Newton", (d, f, s, nts) => new GaussNewtonMultilateralizer(d, f, s)),
-            ("Nelder-Mead", (d, f, s, nts) => new NelderMeadMultilateralizer(d, f, s)),
-            ("BFGS", (d, f, s, nts) => new BfgsMultilateralizer(d, f, s)),
-            ("MLE", (d, f, s, nts) => new MLEMultilateralizer(d, f, s)),
-            ("Nadaraya-Watson", (d, f, s, nts) => new NadarayaWatsonMultilateralizer(d, f, s, nts)),
+            ("Gauss-Newton", (d, f, s, nts, nss, dss) => new GaussNewtonMultilateralizer(d, f, s, nss, dss)),
+            ("Nelder-Mead", (d, f, s, nts, nss, dss) => new NelderMeadMultilateralizer(d, f, s, nss, dss)),
+            ("BFGS", (d, f, s, nts, nss, dss) => new BfgsMultilateralizer(d, f, s, nss, dss)),
+            ("MLE", (d, f, s, nts, nss, dss) => new MLEMultilateralizer(d, f, s, nss, dss)),
+            ("Nadaraya-Watson", (d, f, s, nts, nss, dss) => new NadarayaWatsonMultilateralizer(d, f, s, nts)),
         };
 
         bool allPassed = true;
@@ -282,17 +287,17 @@ class MultiFloorConfidenceTest
             // Using first floor bounds since the locator always targets first floor
             var belowResult = TestConfidenceAtZ(
                 -1.5, first, floors, firstFloorNodes, secondFloorNodes, basementNodes,
-                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore),
+                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore, nodeSettingsStore, deviceSettingsStore),
                 IterationsPerScenario, BaseSeed + 1);
             
             var onResult = TestConfidenceAtZ(
                 1.5, first, floors, firstFloorNodes, secondFloorNodes, basementNodes,
-                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore),
+                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore, nodeSettingsStore, deviceSettingsStore),
                 IterationsPerScenario, BaseSeed + 2);
             
             var aboveResult = TestConfidenceAtZ(
                 4.5, first, floors, firstFloorNodes, secondFloorNodes, basementNodes,
-                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore),
+                config, state, device, nodeTelemetryStore, locatorInfo.Factory(device, first, state, nodeTelemetryStore, nodeSettingsStore, deviceSettingsStore),
                 IterationsPerScenario, BaseSeed + 3);
 
             PrintComparison("Device Below (-1.5m)", belowResult, onResult);

--- a/tests/ESPresense.Companion.Simulation/Program.cs
+++ b/tests/ESPresense.Companion.Simulation/Program.cs
@@ -41,6 +41,26 @@ class MockNodeTelemetryStore : NodeTelemetryStore
 }
 
 /// <summary>
+/// Mock NodeSettingsStore for simulation - no background service needed
+/// </summary>
+class MockNodeSettingsStore : NodeSettingsStore
+{
+    public MockNodeSettingsStore() : base(null!, null!)
+    {
+    }
+}
+
+/// <summary>
+/// Mock DeviceSettingsStore for simulation - no background service needed
+/// </summary>
+class MockDeviceSettingsStore : DeviceSettingsStore
+{
+    public MockDeviceSettingsStore() : base(null!, null!)
+    {
+    }
+}
+
+/// <summary>
 /// Compares actual multilateration algorithms from ESPresense.Companion
 /// </summary>
 class Program
@@ -48,7 +68,7 @@ class Program
     private const int BaseSeed = 12345;
     private const double SuccessThresholdMeters = 1.0;
 
-    private static (Config Config, Floor Floor, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore)
+    private static (Config Config, Floor Floor, State State, Device Device, MockNodeTelemetryStore NodeTelemetryStore, MockNodeSettingsStore NodeSettingsStore, MockDeviceSettingsStore DeviceSettingsStore)
         CreateSimulationContext()
     {
         var floor = new Floor();
@@ -62,12 +82,15 @@ class Program
 
         var mockConfigLoader = new MockConfigLoader(config);
         var nodeTelemetryStore = new MockNodeTelemetryStore();
-        var state = new State(mockConfigLoader, nodeTelemetryStore);
+        var mockNss = new MockNodeSettingsStore();
+        var mockDss = new MockDeviceSettingsStore();
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss);
+        var state = new State(mockConfigLoader, nodeTelemetryStore, mockNss, lazyDss);
 
         var device = new Device("sim-device", "test-discovery", TimeSpan.FromSeconds(30));
         state.Devices[device.Id] = device;
 
-        return (config, floor, state, device, nodeTelemetryStore);
+        return (config, floor, state, device, nodeTelemetryStore, mockNss, mockDss);
     }
 
     private static int SeedFor(string nodeConfigName, string scenarioName)
@@ -121,13 +144,13 @@ class Program
         };
         
         // Locators to test
-        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, ILocate> Factory)[]
+        var locators = new (string Name, Func<Device, Floor, State, NodeTelemetryStore, NodeSettingsStore, DeviceSettingsStore, ILocate> Factory)[]
         {
-            ("Gauss-Newton", (d, f, s, nts) => new GaussNewtonMultilateralizer(d, f, s)),
-            ("Nelder-Mead", (d, f, s, nts) => new NelderMeadMultilateralizer(d, f, s)),
-            ("BFGS", (d, f, s, nts) => new BfgsMultilateralizer(d, f, s)),
-            ("MLE", (d, f, s, nts) => new MLEMultilateralizer(d, f, s)),
-            ("Nadaraya-Watson", (d, f, s, nts) => new NadarayaWatsonMultilateralizer(d, f, s, nts)),
+            ("Gauss-Newton", (d, f, s, nts, nss, dss) => new GaussNewtonMultilateralizer(d, f, s, nss, dss)),
+            ("Nelder-Mead", (d, f, s, nts, nss, dss) => new NelderMeadMultilateralizer(d, f, s, nss, dss)),
+            ("BFGS", (d, f, s, nts, nss, dss) => new BfgsMultilateralizer(d, f, s, nss, dss)),
+            ("MLE", (d, f, s, nts, nss, dss) => new MLEMultilateralizer(d, f, s, nss, dss)),
+            ("Nadaraya-Watson", (d, f, s, nts, nss, dss) => new NadarayaWatsonMultilateralizer(d, f, s, nts)),
         };
         
         int iterations = 100;
@@ -157,7 +180,9 @@ class Program
                             context.Device,
                             context.Floor,
                             context.State,
-                            context.NodeTelemetryStore);
+                            context.NodeTelemetryStore,
+                            context.NodeSettingsStore,
+                            context.DeviceSettingsStore);
                         var report = sim.RunMonteCarlo(
                             iterations,
                             locator,

--- a/tests/ESPresense.Companion.Tests/Controllers/NodeControllerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Controllers/NodeControllerTests.cs
@@ -15,18 +15,15 @@ public class NodeControllerTests
         var mqtt = new Mock<IMqttCoordinator>();
         var nodeSettingsStore = new NodeSettingsStore(mqtt.Object, Mock.Of<ILogger<NodeSettingsStore>>());
         var nodeTelemetryStore = new NodeTelemetryStore(mqtt.Object);
-        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore);
-        var firmwareUpdateJobs = new FirmwareUpdateJobService(
-            nodeSettingsStore,
-            nodeTelemetryStore,
-            new HttpClient(),
-            Mock.Of<ILogger<FirmwareUpdateJobService>>());
+        DeviceSettingsStore? deviceSettingsStore = null;
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore!);
+        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore, nodeSettingsStore, lazyDss);
+        deviceSettingsStore = new DeviceSettingsStore(mqtt.Object, state);
 
-        var sut = new NodeController(nodeSettingsStore, nodeTelemetryStore, state, firmwareUpdateJobs);
+        var sut = new NodeController(nodeSettingsStore, nodeTelemetryStore, state);
 
-        var result = await sut.Update("node-1", new NodeController.NodeUpdate { Url = "https://example.com/firmware.bin" });
+        await sut.Update("node-1", new NodeController.NodeUpdate { Url = "https://example.com/firmware.bin" });
 
-        Assert.That(result, Is.TypeOf<BadRequestObjectResult>());
         mqtt.Verify(x => x.EnqueueAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>()), Times.Never);
     }
 
@@ -39,21 +36,18 @@ public class NodeControllerTests
 
         var nodeSettingsStore = new NodeSettingsStore(mqtt.Object, Mock.Of<ILogger<NodeSettingsStore>>());
         var nodeTelemetryStore = new NodeTelemetryStore(mqtt.Object);
-        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore);
-        var firmwareUpdateJobs = new FirmwareUpdateJobService(
-            nodeSettingsStore,
-            nodeTelemetryStore,
-            new HttpClient(),
-            Mock.Of<ILogger<FirmwareUpdateJobService>>());
+        DeviceSettingsStore? deviceSettingsStore = null;
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore!);
+        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore, nodeSettingsStore, lazyDss);
+        deviceSettingsStore = new DeviceSettingsStore(mqtt.Object, state);
 
-        var sut = new NodeController(nodeSettingsStore, nodeTelemetryStore, state, firmwareUpdateJobs);
+        var sut = new NodeController(nodeSettingsStore, nodeTelemetryStore, state);
 
-        var result = await sut.Update("node-1", new NodeController.NodeUpdate
+        await sut.Update("node-1", new NodeController.NodeUpdate
         {
             Url = "https://github.com/espresense/ESPresense/releases/download/v1/test.bin"
         });
 
-        Assert.That(result, Is.TypeOf<NoContentResult>());
         mqtt.Verify(x => x.EnqueueAsync("espresense/rooms/node-1/update/set", "https://github.com/espresense/ESPresense/releases/download/v1/test.bin", false), Times.Once);
     }
 }

--- a/tests/ESPresense.Companion.Tests/Controllers/StateControllerAnchorTests.cs
+++ b/tests/ESPresense.Companion.Tests/Controllers/StateControllerAnchorTests.cs
@@ -34,8 +34,9 @@ public class StateControllerAnchorTests
 
         _configLoader = new ConfigLoader(_configDir);
         var nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, nodeTelemetryStore);
-        _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, _state);
+        _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDeviceSettingsStore.Object);
+        _state = new State(_configLoader, nodeTelemetryStore, _mockNodeSettingsStore.Object, lazyDss);
 
         var mockEventDispatcher = new Mock<GlobalEventDispatcher>();
 

--- a/tests/ESPresense.Companion.Tests/DeviceAliasIntegrationTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceAliasIntegrationTests.cs
@@ -35,7 +35,10 @@ public class DeviceAliasIntegrationTests
         _mockDeviceServiceLogger = new Mock<ILogger<DeviceService>>();
 
         // Create real instances for integration testing
-        _state = new State(_mockConfigLoader.Object, _mockNodeTelemetryStore.Object);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_mockConfigLoader.Object, _mockNodeTelemetryStore.Object, mockNss.Object, lazyDss);
         _deviceSettingsStore = new DeviceSettingsStore(_mockMqttCoordinator.Object, _state);
         
         // Create DeviceService with required dependencies

--- a/tests/ESPresense.Companion.Tests/DeviceControllerTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceControllerTests.cs
@@ -39,8 +39,10 @@ public class DeviceControllerTests
         var mockMqttCoordinatorInterface = new Mock<IMqttCoordinator>();
         
         var mockNodeTelemetryStore = new Mock<NodeTelemetryStore>(mockMqttCoordinatorInterface.Object);
-        _mockState = new Mock<State>(mockConfigLoader.Object, mockNodeTelemetryStore.Object);
-        _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(mockMqttCoordinatorInterface.Object, _mockState.Object);
+        var mockNss = new Mock<NodeSettingsStore>(mockMqttCoordinatorInterface.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(mockMqttCoordinatorInterface.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDeviceSettingsStore.Object);
+        _mockState = new Mock<State>(mockConfigLoader.Object, mockNodeTelemetryStore.Object, mockNss.Object, lazyDss);
         
         // Create dependencies for DeviceService
         var mockMqttCoordinatorConcrete = CreateMockMqttCoordinator();

--- a/tests/ESPresense.Companion.Tests/DeviceSettingsStoreTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceSettingsStoreTests.cs
@@ -1,6 +1,7 @@
 using ESPresense.Events;
 using ESPresense.Models;
 using ESPresense.Services;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests;
@@ -25,7 +26,10 @@ public class DeviceSettingsStoreTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
 
         _deviceSettingsStore = new DeviceSettingsStore(_mockMqttCoordinator.Object, _state);
 

--- a/tests/ESPresense.Companion.Tests/DeviceTrackerTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceTrackerTests.cs
@@ -41,8 +41,7 @@ public class DeviceTrackerTests
         var state = new State(configLoader, nodeTelemetryStore, mockNss.Object, lazyDss);
         deviceSettingsStore = new DeviceSettingsStore(mqtt, state);
 
-        var distCalc = new DistanceCalculator(mockNss.Object, state);
-        var locator = new DeviceTracker(state, mqtt, new TelemetryService(mqtt), new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
+        var locator = new DeviceTracker(state, mqtt, new TelemetryService(mqtt), new GlobalEventDispatcher(), deviceSettingsStore);
         // Use testData to test locator...
         // Assert.That(result, Is.EqualTo(expectedResult));
     }

--- a/tests/ESPresense.Companion.Tests/DeviceTrackerTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceTrackerTests.cs
@@ -3,6 +3,8 @@ using ESPresense.Controllers;
 using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Newtonsoft.Json;
 
 namespace ESPresense.Companion.Tests;
@@ -33,10 +35,14 @@ public class DeviceTrackerTests
 
         // Create the NodeTelemetryStore instance that's now required by State constructor
         var nodeTelemetryStore = new NodeTelemetryStore(mqtt); // Use the existing mqtt instance
-        var state = new State(configLoader, nodeTelemetryStore);
-        var deviceSettingsStore = new DeviceSettingsStore(mqtt, state);
+        var mockNss = new Mock<NodeSettingsStore>((IMqttCoordinator)mqtt, (ILogger<NodeSettingsStore>)null!);
+        DeviceSettingsStore? deviceSettingsStore = null;
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore!);
+        var state = new State(configLoader, nodeTelemetryStore, mockNss.Object, lazyDss);
+        deviceSettingsStore = new DeviceSettingsStore(mqtt, state);
 
-        var locator = new DeviceTracker(state, mqtt, new TelemetryService(mqtt), new GlobalEventDispatcher(), deviceSettingsStore);
+        var distCalc = new DistanceCalculator(mockNss.Object, state);
+        var locator = new DeviceTracker(state, mqtt, new TelemetryService(mqtt), new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
         // Use testData to test locator...
         // Assert.That(result, Is.EqualTo(expectedResult));
     }

--- a/tests/ESPresense.Companion.Tests/EdgeCases/AnchorEdgeCaseTests.cs
+++ b/tests/ESPresense.Companion.Tests/EdgeCases/AnchorEdgeCaseTests.cs
@@ -28,7 +28,10 @@ public class AnchorEdgeCaseTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
         _deviceSettingsStore = new DeviceSettingsStore(_mockMqttCoordinator.Object, _state);
     }
 

--- a/tests/ESPresense.Companion.Tests/FilteringTests.cs
+++ b/tests/ESPresense.Companion.Tests/FilteringTests.cs
@@ -1,6 +1,7 @@
 using ESPresense.Models;
 using ESPresense.Services;
 using ESPresense.Utils;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using SQLite;
@@ -98,11 +99,15 @@ filtering:
             await configLoader.ConfigAsync(); // Wait for load
 
             var mqttMock = new Mock<MqttCoordinator>(configLoader, NullLogger<MqttCoordinator>.Instance, new MqttNetLogger(), new SupervisorConfigLoader(NullLogger<SupervisorConfigLoader>.Instance));
-            var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object));
+            var mockNss = new Mock<NodeSettingsStore>(mqttMock.Object, (ILogger<NodeSettingsStore>)null!);
+            var mockDss = new Mock<DeviceSettingsStore>(mqttMock.Object, (State)null!);
+            var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+            var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object), mockNss.Object, lazyDss);
 
             var tele = new TelemetryService(mqttMock.Object);
             var deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
-            var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
+            var distCalc = new DistanceCalculator(mockNss.Object, state);
+            var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
             var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
             var leaseServiceMock = new Mock<ILeaseService>();
             var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history, leaseServiceMock.Object);

--- a/tests/ESPresense.Companion.Tests/FilteringTests.cs
+++ b/tests/ESPresense.Companion.Tests/FilteringTests.cs
@@ -106,8 +106,7 @@ filtering:
 
             var tele = new TelemetryService(mqttMock.Object);
             var deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
-            var distCalc = new DistanceCalculator(mockNss.Object, state);
-            var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
+            var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
             var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
             var leaseServiceMock = new Mock<ILeaseService>();
             var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history, leaseServiceMock.Object);

--- a/tests/ESPresense.Companion.Tests/Integration/AnchoredDeviceIntegrationTests.cs
+++ b/tests/ESPresense.Companion.Tests/Integration/AnchoredDeviceIntegrationTests.cs
@@ -30,7 +30,10 @@ public class AnchoredDeviceIntegrationTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
         _deviceSettingsStore = new DeviceSettingsStore(_mockMqttCoordinator.Object, _state);
     }
 

--- a/tests/ESPresense.Companion.Tests/Locators/BaseMultilateralizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/BaseMultilateralizerTests.cs
@@ -14,6 +14,8 @@ public class BaseMultilateralizerTests
     private string _configDir;
     private NodeTelemetryStore _nodeTelemetryStore;
     private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNodeSettingsStore;
+    private Mock<DeviceSettingsStore> _mockDeviceSettingsStore;
 
     [SetUp]
     public void Setup()
@@ -24,7 +26,10 @@ public class BaseMultilateralizerTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        _mockNodeSettingsStore = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, null!);
+        _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDeviceSettingsStore.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, _mockNodeSettingsStore.Object, lazyDss);
     }
 
     [TearDown]
@@ -67,18 +72,25 @@ public class BaseMultilateralizerTests
         return floor;
     }
 
-    private Node CreateTestNode(string id, double x, double y, double z, Floor floor)
+    private Node CreateTestNode(string id, double x, double y, double z, Floor floor, string? antenna = null)
     {
         var node = new Node(id, NodeSourceType.Config);
-        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z } };
-        node.Update(_configLoader.Config!, configNode, new[] { floor });
+        // Set Id explicitly so ConfigNode.GetId() == id without ToSnakeCase transformation
+        var configNode = new ConfigNode { Id = id, Name = id, Point = new double[] { x, y, z }, Antenna = antenna };
+        // Ensure State.Config is non-null so EnrichNodes can look up antenna profile
+        if (_state.Config == null)
+            _state.Config = new Config();
+        node.Update(_state.Config, configNode, new[] { floor });
         _state.Nodes[id] = node;
+        // Register the ConfigNode in State.Config.Nodes so EnrichNodes can look up antenna profile
+        _state.Config.Nodes = (_state.Config.Nodes ?? Array.Empty<ConfigNode>())
+            .Append(configNode).ToArray();
         return node;
     }
 
     private TestMultilateralizer CreateTestMultilateralizer(Device device, Floor floor)
     {
-        return new TestMultilateralizer(device, floor, _state);
+        return new TestMultilateralizer(device, floor, _state, _mockNodeSettingsStore.Object, _mockDeviceSettingsStore.Object);
     }
 
     [Test]
@@ -235,17 +247,438 @@ public class BaseMultilateralizerTests
         Assert.That(result, Is.False); // Should return false because movement < 0.1
     }
 
+    // -----------------------------------------------------------------------
+    // Tests verifying EnrichNodes correctly threads GMaxDb and antenna angles
+    // through from config/calibration to DeviceToNode enrichment fields.
+    // These cover: backward-compat null-GMaxDb fallback and az/el threading.
+    //
+    // NOTE: These tests are async so they can await ConfigLoader.ConfigAsync()
+    // before running, ensuring the one-time asynchronous config load (which
+    // fires State.ConfigChanged) has completed.  After that, we pin State.Config
+    // to a known test Config so EnrichNodes sees deterministic data.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Helper: create 3 live nodes (non-zero RSSI) attached to <paramref name="device"/>
+    /// and registered in <paramref name="floor"/>, WITHOUT modifying State.Config.Nodes.
+    /// Callers are responsible for setting State.Config after the ConfigLoader race is resolved.
+    /// </summary>
+    private Device CreateDeviceWithThreeRssiNodes(Floor floor)
+    {
+        var device = new Device("dev", null, TimeSpan.FromSeconds(30));
+        var nodeIds  = new[] { "n1", "n2", "n3" };
+        var positions = new[] { (0.0, 0.0), (5.0, 0.0), (0.0, 5.0) };
+        for (int k = 0; k < 3; k++)
+        {
+            // CreateTestNode registers in _state.Nodes and sets _state.Config.Nodes,
+            // but we will overwrite State.Config after ConfigAsync() anyway.
+            var node = CreateTestNode(nodeIds[k], positions[k].Item1, positions[k].Item2, 0, floor);
+            var dn = new DeviceToNode(device, node)
+            {
+                Distance = 3.0,
+                LastHit  = DateTime.UtcNow,
+                Rssi     = -70.0,   // non-zero → EnrichNodes activates enrichment path
+                RefRssi  = -59.0
+            };
+            device.Nodes[nodeIds[k]] = dn;
+        }
+        return device;
+    }
+
+    /// <summary>
+    /// Pins State.Config to a fresh Config whose Nodes array is built from
+    /// <paramref name="device"/>'s nodes with the given <paramref name="antenna"/> profile.
+    /// Call AFTER awaiting ConfigAsync() to avoid ConfigChanged races.
+    /// </summary>
+    private void PinStateConfig(Device device, string? antenna)
+    {
+        _state.Config = new Config
+        {
+            Nodes = device.Nodes.Values
+                .Select(dn => new ConfigNode { Id = dn.Node!.Id, Antenna = antenna })
+                .ToArray()
+        };
+    }
+
+    [Test]
+    public async Task EnrichNodes_NullAntenna_SetsNodeGMaxDbToNull_BackwardCompatibility()
+    {
+        // Await initial config load so ConfigChanged has fired; no more fires after this.
+        await _configLoader.ConfigAsync();
+
+        // Arrange: nodes without antenna configured → NodeGMaxDb must remain null
+        // so Distance falls back to firmware (_payloadDistance).
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: null);   // sets State.Config with no antenna nodes
+
+        _mockNodeSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new NodeSettings
+            {
+                Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+            });
+        _mockDeviceSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new DeviceSettings());
+
+        var capturer = new CapturingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object);
+
+        var scenario = new Scenario(_state.Config, capturer, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        // Act
+        capturer.Locate(scenario);
+
+        // Assert: every node should have NodeGMaxDb == null (backward-compat path)
+        Assert.That(capturer.CapturedGMaxDb, Is.Not.Empty,
+            "CapturingMultilateralizer should have captured enriched nodes");
+        Assert.That(capturer.CapturedGMaxDb, Has.All.Null,
+            "Nodes with null antenna must yield null NodeGMaxDb so " +
+            "Distance falls back to firmware payload distance");
+    }
+
+    [Test]
+    public async Task EnrichNodes_WithAntenna_SetsNodeGMaxDb()
+    {
+        // Await initial config load so ConfigChanged has fired; no more fires after this.
+        await _configLoader.ConfigAsync();
+
+        // Arrange: nodes WITH antenna=pcb_ifa configured → NodeGMaxDb must equal 3.4
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");    // sets State.Config with pcb_ifa antenna nodes
+
+        _mockNodeSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new NodeSettings
+            {
+                Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+            });
+        _mockDeviceSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new DeviceSettings());
+
+        var capturer = new CapturingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object);
+
+        var scenario = new Scenario(_state.Config, capturer, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        // Act
+        capturer.Locate(scenario);
+
+        // Assert: every node should have NodeGMaxDb == 3.4 (pcb_ifa profile)
+        Assert.That(capturer.CapturedGMaxDb, Is.Not.Empty);
+        Assert.That(capturer.CapturedGMaxDb, Has.All.EqualTo(3.4),
+            "Nodes with antenna=pcb_ifa must yield NodeGMaxDb=3.4");
+    }
+
+    [Test]
+    public async Task EnrichNodes_ReadsAzimuthElevationFromCalibration()
+    {
+        // Await initial config load so no ConfigChanged races.
+        await _configLoader.ConfigAsync();
+
+        // Arrange: calibration has Azimuth=45°, Elevation=30°.
+        // After EnrichNodes these must be converted to radians and stored.
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        var calSettings = new NodeSettings
+        {
+            Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+        };
+        _mockNodeSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(calSettings);
+        _mockDeviceSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new DeviceSettings());
+
+        var capturer = new CapturingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object);
+
+        var scenario = new Scenario(_state.Config, capturer, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        // Act
+        capturer.Locate(scenario);
+
+        // Assert: azimuth and elevation converted correctly to radians
+        double expectedAzRad = 45.0 * Math.PI / 180.0;
+        double expectedElRad = 30.0 * Math.PI / 180.0;
+
+        Assert.That(capturer.CapturedAzimuthRad, Is.Not.Empty);
+        foreach (var az in capturer.CapturedAzimuthRad)
+            Assert.That(az, Is.EqualTo(expectedAzRad).Within(1e-9),
+                "NodeAzimuthRad must equal calibration azimuth (deg→rad)");
+        foreach (var el in capturer.CapturedElevationRad)
+            Assert.That(el, Is.EqualTo(expectedElRad).Within(1e-9),
+                "NodeElevationRad must equal calibration elevation (deg→rad)");
+    }
+
+    [Test]
+    public async Task EnrichNodes_MissingAngles_UsesDefaultZeroAngles()
+    {
+        // Await initial config load so no ConfigChanged races.
+        await _configLoader.ConfigAsync();
+
+        // Arrange: no calibration → antenna profile still active with default 0°/0° angles.
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        _mockNodeSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new NodeSettings()); // no calibration values
+        _mockDeviceSettingsStore
+            .Setup(x => x.Get(It.IsAny<string>()))
+            .Returns(new DeviceSettings());
+
+        var capturer = new CapturingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object);
+
+        var scenario = new Scenario(_state.Config, capturer, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        // Act
+        capturer.Locate(scenario);
+
+        // Antenna profile is active even without calibration — defaults to az=0°, el=0°
+        Assert.That(capturer.CapturedAzimuthRad, Has.All.EqualTo(0.0).Within(1e-9),
+            "Azimuth should default to 0° when no calibration is saved");
+        Assert.That(capturer.CapturedElevationRad, Has.All.EqualTo(0.0).Within(1e-9),
+            "Elevation should default to 0° when no calibration is saved");
+        Assert.That(capturer.CapturedGMaxDb, Has.All.EqualTo(3.4),
+            "Directional gain should be active with pcb_ifa profile (GMaxDb=3.4)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests verifying the 3-iteration gain-correction loop in Locate().
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Solve() is called exactly 3 times when every iteration succeeds.
+    /// </summary>
+    [Test]
+    public async Task Locate_CallsSolveExactlyThreeTimes()
+    {
+        await _configLoader.ConfigAsync();
+
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        _mockNodeSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new NodeSettings
+        {
+            Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+        });
+        _mockDeviceSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new DeviceSettings());
+
+        var counter = new CountingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object,
+            returnNullOnIteration: -1); // never return null
+
+        var scenario = new Scenario(_state.Config, counter, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        counter.Locate(scenario);
+
+        Assert.That(counter.SolveCallCount, Is.EqualTo(3),
+            "Solve() must be called exactly 3 times for the gain-correction loop");
+    }
+
+    /// <summary>
+    /// On iteration 0 NodeCosTheta is null; on iterations 1 and 2 it is non-null
+    /// (i.e. UpdateNodeCosTheta was invoked with the previous result).
+    /// </summary>
+    [Test]
+    public async Task Locate_GainCorrection_IsNullOnIteration0_NonNullOnIterations1And2()
+    {
+        await _configLoader.ConfigAsync();
+
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        _mockNodeSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new NodeSettings
+        {
+            Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+        });
+        _mockDeviceSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new DeviceSettings());
+
+        var counter = new CountingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object,
+            returnNullOnIteration: -1);
+
+        var scenario = new Scenario(_state.Config, counter, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        counter.Locate(scenario);
+
+        Assert.That(counter.SolveCallCount, Is.EqualTo(3));
+
+        // Iteration 0: no cos(θ) computed yet → all nodes have NodeCosTheta == null
+        Assert.That(counter.CosThetaPerIteration[0], Has.All.Null,
+            "NodeCosTheta must be null on iteration 0 (no previous result to compute from)");
+
+        // Iterations 1 and 2: UpdateNodeCosTheta was called → all nodes have a value
+        Assert.That(counter.CosThetaPerIteration[1], Has.None.Null,
+            "NodeCosTheta must be non-null on iteration 1 (cos(θ) computed from iteration-0 result)");
+        Assert.That(counter.CosThetaPerIteration[2], Has.None.Null,
+            "NodeCosTheta must be non-null on iteration 2 (cos(θ) computed from iteration-1 result)");
+    }
+
+    /// <summary>
+    /// After Locate() finishes the loop successfully, enrichment fields on every node
+    /// (NodeGMaxDb and NodeCosTheta) are reset to null.
+    /// </summary>
+    [Test]
+    public async Task Locate_EnrichmentIsResetAfterSuccessfulLoop()
+    {
+        await _configLoader.ConfigAsync();
+
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        _mockNodeSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new NodeSettings
+        {
+            Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+        });
+        _mockDeviceSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new DeviceSettings());
+
+        var counter = new CountingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object,
+            returnNullOnIteration: -1);
+
+        var scenario = new Scenario(_state.Config, counter, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        counter.Locate(scenario);
+
+        // After Locate() returns, ResetEnrichment() must have cleared gain fields
+        var dnNodes = device.Nodes.Values.ToArray();
+        Assert.That(dnNodes.Select(dn => dn.NodeGMaxDb), Has.All.Null,
+            "NodeGMaxDb must be null after the loop (ResetEnrichment)");
+        Assert.That(dnNodes.Select(dn => dn.NodeCosTheta), Has.All.Null,
+            "NodeCosTheta must be null after the loop (ResetEnrichment)");
+    }
+
+    /// <summary>
+    /// When Solve() returns null on a given iteration the loop exits early,
+    /// ResetEnrichment is called, and Solve is not called again.
+    /// </summary>
+    [Test]
+    public async Task Locate_NullSolveOnIteration1_StopsLoopAndResetsEnrichment()
+    {
+        await _configLoader.ConfigAsync();
+
+        var floor  = CreateTestFloor();
+        var device = CreateDeviceWithThreeRssiNodes(floor);
+        PinStateConfig(device, antenna: "pcb_ifa");
+
+        _mockNodeSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new NodeSettings
+        {
+            Calibration = new CalibrationSettings { Azimuth = 45.0, Elevation = 30.0 }
+        });
+        _mockDeviceSettingsStore.Setup(x => x.Get(It.IsAny<string>())).Returns(new DeviceSettings());
+
+        // Return null on iteration 1 (0-indexed) so the loop stops after 2 calls
+        var counter = new CountingMultilateralizer(
+            device, floor, _state,
+            _mockNodeSettingsStore.Object,
+            _mockDeviceSettingsStore.Object,
+            returnNullOnIteration: 1);
+
+        var scenario = new Scenario(_state.Config, counter, "Test");
+        scenario.ResetLocation(new Point3D(2, 2, 0));
+
+        counter.Locate(scenario);
+
+        Assert.That(counter.SolveCallCount, Is.EqualTo(2),
+            "When Solve returns null on iteration 1 the loop must stop (only 2 calls total)");
+
+        // Enrichment must still be reset even on early exit
+        var dnNodes = device.Nodes.Values.ToArray();
+        Assert.That(dnNodes.Select(dn => dn.NodeGMaxDb), Has.All.Null,
+            "NodeGMaxDb must be null after early-exit (ResetEnrichment)");
+        Assert.That(dnNodes.Select(dn => dn.NodeCosTheta), Has.All.Null,
+            "NodeCosTheta must be null after early-exit (ResetEnrichment)");
+    }
+
+    /// <summary>
+    /// Multilateralizer that counts Solve() calls and captures NodeCosTheta per iteration.
+    /// Optionally returns null on a given iteration index to test early-exit behaviour.
+    /// </summary>
+    private class CountingMultilateralizer : BaseMultilateralizer
+    {
+        private readonly int _returnNullOnIteration;
+
+        public int SolveCallCount { get; private set; }
+
+        /// <summary>Snapshot of NodeCosTheta for every node at each Solve() call.</summary>
+        public List<List<double?>> CosThetaPerIteration { get; } = new();
+
+        public CountingMultilateralizer(
+            Device device, Floor floor, State state,
+            NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings,
+            int returnNullOnIteration)
+            : base(device, floor, state, nodeSettings, deviceSettings)
+        {
+            _returnNullOnIteration = returnNullOnIteration;
+        }
+
+        protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
+        {
+            // Capture cos(θ) snapshot at this iteration
+            CosThetaPerIteration.Add(nodes.Select(dn => dn.NodeCosTheta).ToList());
+
+            if (SolveCallCount == _returnNullOnIteration)
+            {
+                SolveCallCount++;
+                return null;
+            }
+
+            SolveCallCount++;
+            // Return a fixed non-null point so UpdateNodeCosTheta can compute meaningful angles
+            return new Point3D(2, 2, 0);
+        }
+    }
+
     // Test multilateralizer that exposes protected methods for testing
     private class TestMultilateralizer : BaseMultilateralizer
     {
-        public TestMultilateralizer(Device device, Floor floor, State state)
-            : base(device, floor, state)
+        public TestMultilateralizer(Device device, Floor floor, State state, NodeSettingsStore nodeSettings, DeviceSettingsStore deviceSettings)
+            : base(device, floor, state, nodeSettings, deviceSettings)
         {
         }
 
-        public override bool Locate(Scenario scenario)
+        /// <summary>
+        /// Minimal Solve() implementation — always returns null so the base template
+        /// falls back to the guess.  Tests exercise individual helper methods directly
+        /// via the Public* wrappers below rather than going through Locate().
+        /// </summary>
+        protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
         {
-            return true;
+            return null;
         }
 
         public bool PublicInitializeScenario(Scenario scenario, out DeviceToNode[] nodes, out Point3D guess)
@@ -271,6 +704,47 @@ public class BaseMultilateralizerTests
         public bool PublicFinalizeScenario(Scenario scenario, int confidence)
         {
             return FinalizeScenario(scenario, confidence);
+        }
+    }
+
+    /// <summary>
+    /// A multilateralizer that captures enrichment state on the first Solve() call
+    /// so tests can verify what EnrichNodes stored without needing to expose the
+    /// private method.  Returns a fixed non-null point so the iteration completes.
+    /// </summary>
+    private class CapturingMultilateralizer : BaseMultilateralizer
+    {
+        private int _callCount;
+
+        /// <summary>NodeGMaxDb values captured at first Solve() call (iteration 0).</summary>
+        public List<double?> CapturedGMaxDb      { get; } = new();
+        /// <summary>NodeAzimuthRad values captured at first Solve() call.</summary>
+        public List<double?> CapturedAzimuthRad  { get; } = new();
+        /// <summary>NodeElevationRad values captured at first Solve() call.</summary>
+        public List<double?> CapturedElevationRad { get; } = new();
+
+        public CapturingMultilateralizer(
+            Device device, Floor floor, State state,
+            NodeSettingsStore nodeSettings,
+            DeviceSettingsStore deviceSettings)
+            : base(device, floor, state, nodeSettings, deviceSettings) { }
+
+        protected override Point3D? Solve(Scenario scenario, DeviceToNode[] nodes, Point3D guess)
+        {
+            if (_callCount == 0)
+            {
+                // Capture a snapshot of enrichment fields before any cosTheta update.
+                foreach (var dn in nodes)
+                {
+                    CapturedGMaxDb.Add(dn.NodeGMaxDb);
+                    CapturedAzimuthRad.Add(dn.NodeAzimuthRad);
+                    CapturedElevationRad.Add(dn.NodeElevationRad);
+                }
+            }
+            _callCount++;
+            // Return a non-null point so the 3-iteration loop completes normally
+            // (prevents the null-path which calls ResetEnrichment before we capture).
+            return new Point3D(1, 1, 0);
         }
     }
 }

--- a/tests/ESPresense.Companion.Tests/Locators/BfgsMultilateralizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/BfgsMultilateralizerTests.cs
@@ -2,6 +2,7 @@ using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Locators;
@@ -14,6 +15,8 @@ public class BfgsMultilateralizerTests
     private string _configDir;
     private NodeTelemetryStore _nodeTelemetryStore;
     private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
 
     [SetUp]
     public void Setup()
@@ -24,7 +27,10 @@ public class BfgsMultilateralizerTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, _mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -67,10 +73,10 @@ public class BfgsMultilateralizerTests
         return floor;
     }
 
-    private Node CreateTestNode(string id, double x, double y, double z, Floor floor)
+    private Node CreateTestNode(string id, double x, double y, double z, Floor floor, string? antenna = null)
     {
         var node = new Node(id, NodeSourceType.Config);
-        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z } };
+        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z }, Antenna = antenna };
         node.Update(_configLoader.Config!, configNode, new[] { floor });
         _state.Nodes[id] = node;
         return node;
@@ -108,7 +114,7 @@ public class BfgsMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act
@@ -142,7 +148,7 @@ public class BfgsMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act
@@ -189,7 +195,7 @@ public class BfgsMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act
@@ -236,7 +242,7 @@ public class BfgsMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act
@@ -263,7 +269,7 @@ public class BfgsMultilateralizerTests
         device.Nodes["node2"] = new DeviceToNode(device, node2) { Distance = 2.5, LastHit = DateTime.UtcNow };
         device.Nodes["node3"] = new DeviceToNode(device, node3) { Distance = 2.5, LastHit = DateTime.UtcNow };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act
@@ -320,7 +326,7 @@ public class BfgsMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new BfgsMultilateralizer(device, floor, _state);
+        var multilateralizer = new BfgsMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "BFGS");
 
         // Act

--- a/tests/ESPresense.Companion.Tests/Locators/MLEMultilateralizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/MLEMultilateralizerTests.cs
@@ -2,6 +2,7 @@ using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Locators;
@@ -14,6 +15,8 @@ public class MLEMultilateralizerTests
     private string _configDir;
     private NodeTelemetryStore _nodeTelemetryStore;
     private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
 
     [SetUp]
     public void Setup()
@@ -24,7 +27,10 @@ public class MLEMultilateralizerTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, _mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -73,10 +79,10 @@ public class MLEMultilateralizerTests
         return floor;
     }
 
-    private Node CreateTestNode(string id, double x, double y, double z, Floor floor)
+    private Node CreateTestNode(string id, double x, double y, double z, Floor floor, string? antenna = null)
     {
         var node = new Node(id, NodeSourceType.Config);
-        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z } };
+        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z }, Antenna = antenna };
         node.Update(_configLoader.Config!, configNode, new[] { floor });
         _state.Nodes[id] = node;
         return node;
@@ -114,7 +120,7 @@ public class MLEMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act
@@ -148,7 +154,7 @@ public class MLEMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act
@@ -198,7 +204,7 @@ public class MLEMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act
@@ -225,7 +231,7 @@ public class MLEMultilateralizerTests
         device.Nodes["node2"] = new DeviceToNode(device, node2) { Distance = 2.5, LastHit = DateTime.UtcNow };
         device.Nodes["node3"] = new DeviceToNode(device, node3) { Distance = 2.5, LastHit = DateTime.UtcNow };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act
@@ -265,7 +271,7 @@ public class MLEMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act
@@ -311,7 +317,7 @@ public class MLEMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new MLEMultilateralizer(device, floor, _state);
+        var multilateralizer = new MLEMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "MLE");
 
         // Act

--- a/tests/ESPresense.Companion.Tests/Locators/NadarayaWatsonMultilateralizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/NadarayaWatsonMultilateralizerTests.cs
@@ -2,6 +2,7 @@ using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Locators;
@@ -15,6 +16,8 @@ public class NadarayaWatsonMultilateralizerTests
     private NodeTelemetryStore _nodeTelemetryStore;
     private Mock<IMqttCoordinator> _mockMqttCoordinator;
     private Mock<NodeTelemetryStore> _mockNodeTelemetryStore;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
 
     [SetUp]
     public void Setup()
@@ -27,7 +30,10 @@ public class NadarayaWatsonMultilateralizerTests
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
         _mockNodeTelemetryStore = new Mock<NodeTelemetryStore>(_mockMqttCoordinator.Object);
         _mockNodeTelemetryStore.Setup(n => n.Online(It.IsAny<string>())).Returns(true);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, _mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -76,10 +82,10 @@ public class NadarayaWatsonMultilateralizerTests
         return floor;
     }
 
-    private Node CreateTestNode(string id, double x, double y, double z, Floor floor)
+    private Node CreateTestNode(string id, double x, double y, double z, Floor floor, string? antenna = null)
     {
         var node = new Node(id, NodeSourceType.Config);
-        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z } };
+        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z }, Antenna = antenna };
         node.Update(_configLoader.Config!, configNode, new[] { floor });
         _state.Nodes[id] = node;
         return node;

--- a/tests/ESPresense.Companion.Tests/Locators/NearestNodeTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/NearestNodeTests.cs
@@ -2,6 +2,7 @@ using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Locators;
@@ -24,7 +25,10 @@ public class NearestNodeTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -74,14 +78,15 @@ public class NearestNodeTests
         };
     }
 
-    private Node CreateTestNode(string id, string? name, Point3D location, params Floor[] floors)
+    private Node CreateTestNode(string id, string? name, Point3D location, string? antenna = null, params Floor[] floors)
     {
         var node = new Node(id, NodeSourceType.Config);
         var configNode = new ConfigNode
         {
             Id = id,
             Name = name,
-            Point = new[] { location.X, location.Y, location.Z }
+            Point = new[] { location.X, location.Y, location.Z },
+            Antenna = null
         };
 
         node.Update(_configLoader.Config!, configNode, floors);
@@ -127,7 +132,7 @@ public class NearestNodeTests
             room);
 
         var location = new Point3D(1.0, 1.0, 0.0);
-        var node = CreateTestNode("node1", "Node 1", location, outsideFloor, insideFloor);
+        var node = CreateTestNode("node1", "Node 1", location, null, outsideFloor, insideFloor);
         var device = CreateDeviceWithNode(node, 1.0);
 
         var locator = new NearestNode(device, _state);
@@ -166,7 +171,7 @@ public class NearestNodeTests
             room);
 
         var location = new Point3D(1.0, 1.0, 0.0);
-        var node = CreateTestNode("kitchen", "Kitchen Node", location, floor);
+        var node = CreateTestNode("kitchen", "Kitchen Node", location, null, floor);
         var device = CreateDeviceWithNode(node, 1.0);
 
         var locator = new NearestNode(device, _state);

--- a/tests/ESPresense.Companion.Tests/Locators/NelderMeadMultilateralizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Locators/NelderMeadMultilateralizerTests.cs
@@ -2,6 +2,7 @@ using ESPresense.Locators;
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Locators;
@@ -14,6 +15,8 @@ public class NelderMeadMultilateralizerTests
     private string _configDir;
     private NodeTelemetryStore _nodeTelemetryStore;
     private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
 
     [SetUp]
     public void Setup()
@@ -24,7 +27,10 @@ public class NelderMeadMultilateralizerTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, _mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -73,10 +79,10 @@ public class NelderMeadMultilateralizerTests
         return floor;
     }
 
-    private Node CreateTestNode(string id, double x, double y, double z, Floor floor)
+    private Node CreateTestNode(string id, double x, double y, double z, Floor floor, string? antenna = null)
     {
         var node = new Node(id, NodeSourceType.Config);
-        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z } };
+        var configNode = new ConfigNode { Name = id, Point = new double[] { x, y, z }, Antenna = antenna };
         node.Update(_configLoader.Config!, configNode, new[] { floor });
         _state.Nodes[id] = node;
         return node;
@@ -114,7 +120,7 @@ public class NelderMeadMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state);
+        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "NelderMead");
 
         // Act
@@ -148,7 +154,7 @@ public class NelderMeadMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state);
+        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "NelderMead");
 
         // Act
@@ -198,7 +204,7 @@ public class NelderMeadMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state);
+        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "NelderMead");
 
         // Act
@@ -225,7 +231,7 @@ public class NelderMeadMultilateralizerTests
         device.Nodes["node2"] = new DeviceToNode(device, node2) { Distance = 2.5, LastHit = DateTime.UtcNow };
         device.Nodes["node3"] = new DeviceToNode(device, node3) { Distance = 2.5, LastHit = DateTime.UtcNow };
 
-        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state);
+        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "NelderMead");
 
         // Act
@@ -265,7 +271,7 @@ public class NelderMeadMultilateralizerTests
             LastHit = DateTime.UtcNow
         };
 
-        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state);
+        var multilateralizer = new NelderMeadMultilateralizer(device, floor, _state, _mockNss.Object, _mockDss.Object);
         var scenario = new Scenario(_configLoader.Config, multilateralizer, "NelderMead");
 
         // Act

--- a/tests/ESPresense.Companion.Tests/MappingServiceTests.cs
+++ b/tests/ESPresense.Companion.Tests/MappingServiceTests.cs
@@ -19,10 +19,10 @@ public class MappingServiceTests
         return f;
     }
 
-    private static Node MakeNode(string id, string name, IEnumerable<Floor> floors)
+    private static Node MakeNode(string id, string name, IEnumerable<Floor> floors, string? antenna = null)
     {
         var n = new Node(id, NodeSourceType.Config);
-        n.Update(new Config(), new ConfigNode { Id = id, Name = name, Point = new[] { 1.0, 2.0, 3.0 }, Floors = floors.Select(f => f.Id!).ToArray(), Stationary = true }, floors);
+        n.Update(new Config(), new ConfigNode { Id = id, Name = name, Point = new[] { 1.0, 2.0, 3.0 }, Floors = floors.Select(f => f.Id!).ToArray(), Stationary = true, Antenna = antenna }, floors);
         return n;
     }
 

--- a/tests/ESPresense.Companion.Tests/Models/StateAnchorTests.cs
+++ b/tests/ESPresense.Companion.Tests/Models/StateAnchorTests.cs
@@ -1,6 +1,7 @@
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Models;
@@ -23,7 +24,10 @@ public class StateAnchorTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
         _deviceSettingsStore = new DeviceSettingsStore(_mockMqttCoordinator.Object, _state);
     }
 

--- a/tests/ESPresense.Companion.Tests/Models/StateOptimizationAnchorTests.cs
+++ b/tests/ESPresense.Companion.Tests/Models/StateOptimizationAnchorTests.cs
@@ -1,6 +1,7 @@
 using ESPresense.Models;
 using ESPresense.Services;
 using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace ESPresense.Companion.Tests.Models;
@@ -22,7 +23,10 @@ public class StateOptimizationAnchorTests
 
         _configLoader = new ConfigLoader(_configDir);
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        var mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => mockDss.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
     }
 
     [TearDown]
@@ -244,6 +248,52 @@ public class StateOptimizationAnchorTests
         var anchorMeasures = snapshot.Measures.Where(m => m.Tx.Id == device.Id).ToList();
         Assert.That(anchorMeasures, Has.Count.EqualTo(1), "Should only include nodes with locations");
         Assert.That(anchorMeasures[0].Rx.Id, Is.EqualTo(nodeWithLocation.Id));
+    }
+
+    [Test]
+    public void TakeOptimizationSnapshot_SetsIsNodeAndGMaxForEsPresenseNodes()
+    {
+        // Arrange - create infrastructure node with antenna profile configured
+        // Ensure State.Config is non-null so ResolveAntenna works in TakeOptimizationSnapshot
+        if (_state.Config == null) _state.Config = new Config();
+
+        var node1 = new Node("node1", NodeSourceType.Config);
+        var configNode1 = new ConfigNode { Name = "Node 1", Point = new double[] { 0, 0, 0 }, Antenna = "pcb_ifa" };
+        node1.Update(_state.Config, configNode1, Enumerable.Empty<Floor>());
+        _state.Nodes["node1"] = node1;
+
+        var node2 = new Node("node2", NodeSourceType.Config);
+        var configNode2 = new ConfigNode { Name = "Node 2", Point = new double[] { 5, 0, 0 } };
+        node2.Update(_state.Config, configNode2, Enumerable.Empty<Floor>());
+        _state.Nodes["node2"] = node2;
+
+        var device = new Device("anchored-device", null, TimeSpan.FromSeconds(30));
+        device.SetAnchor(new DeviceAnchor(new MathNet.Spatial.Euclidean.Point3D(2.5, 2.5, 0), null, null));
+        _state.Devices["anchored-device"] = device;
+
+        device.Nodes["node1"] = new DeviceToNode(device, node1) { Distance = 3.5, Rssi = -60, RefRssi = -59, LastHit = DateTime.UtcNow };
+        device.Nodes["node2"] = new DeviceToNode(device, node2) { Distance = 4.2, Rssi = -65, RefRssi = -59, LastHit = DateTime.UtcNow };
+
+        // Act
+        var snapshot = _state.TakeOptimizationSnapshot();
+
+        // Assert - ESPresense infrastructure nodes should have IsNode=true
+        var rxNode1 = snapshot.Measures.FirstOrDefault(m => m.Rx.Id == "node1")?.Rx;
+        Assert.That(rxNode1, Is.Not.Null, "node1 should appear as Rx");
+        Assert.That(rxNode1!.IsNode, Is.True, "ESPresense node1 should have IsNode=true");
+        // pcb_ifa: GMaxDb=3.4 dB → linear GMax = 10^(3.4/10)
+        Assert.That(rxNode1.GMax, Is.EqualTo(Math.Pow(10.0, 3.4 / 10.0)).Within(1e-9), "GMax should be set from antenna profile");
+
+        var rxNode2 = snapshot.Measures.FirstOrDefault(m => m.Rx.Id == "node2")?.Rx;
+        Assert.That(rxNode2, Is.Not.Null, "node2 should appear as Rx");
+        Assert.That(rxNode2!.IsNode, Is.True, "ESPresense node2 should have IsNode=true");
+        // No antenna configured → GMax stays at default 1.0
+        Assert.That(rxNode2.GMax, Is.EqualTo(1.0), "GMax should stay at 1.0 when no antenna is configured");
+
+        // The anchored device (Tx) should NOT be marked as IsNode
+        var txDevice = snapshot.Measures.FirstOrDefault(m => m.Tx.Id == "anchored-device")?.Tx;
+        Assert.That(txDevice, Is.Not.Null);
+        Assert.That(txDevice!.IsNode, Is.False, "Anchored BLE device should NOT have IsNode=true");
     }
 
     [Test]

--- a/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
+++ b/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
@@ -3,6 +3,7 @@ using ESPresense.Locators;
 using ESPresense.Services;
 using ESPresense.Utils;
 using ESPresense.Controllers;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using SQLite;
@@ -12,6 +13,16 @@ namespace ESPresense.Companion.Tests;
 
 public class MultiScenarioLocatorTests
 {
+    private static (State State, DeviceSettingsStore DeviceSettingsStore) CreateStateAndStores(ConfigLoader configLoader, Mock<MqttCoordinator> mqttMock)
+    {
+        DeviceSettingsStore? deviceSettingsStore = null;
+        var nodeSettingsStore = new Mock<NodeSettingsStore>(mqttMock.Object, NullLogger<NodeSettingsStore>.Instance);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore!);
+        var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object), nodeSettingsStore.Object, lazyDss);
+        deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
+        return (state, deviceSettingsStore);
+    }
+
     private class DummyLocator : ILocate
     {
         public bool Locate(Scenario scenario) => true;
@@ -32,10 +43,10 @@ public class MultiScenarioLocatorTests
             new MqttNetLogger(),
             supervisor);
 
-        var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object));
+        var (state, deviceSettingsStore) = CreateStateAndStores(configLoader, mqttMock);
         var tele = new TelemetryService(mqttMock.Object);
-        var deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
-        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
+        var distCalc = new DistanceCalculator(new Mock<NodeSettingsStore>(mqttMock.Object, NullLogger<NodeSettingsStore>.Instance).Object, state);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
         var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
         var leaseServiceMock = new Mock<ILeaseService>();
 
@@ -79,10 +90,10 @@ public class MultiScenarioLocatorTests
             supervisor)
         { CallBase = true };
 
-        var state = new State(configLoader, new NodeTelemetryStore(mqttMock.Object));
+        var (state, deviceSettingsStore) = CreateStateAndStores(configLoader, mqttMock);
         var tele = new TelemetryService(mqttMock.Object);
-        var deviceSettingsStore = new DeviceSettingsStore(mqttMock.Object, state);
-        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
+        var distCalc = new DistanceCalculator(new Mock<NodeSettingsStore>(mqttMock.Object, NullLogger<NodeSettingsStore>.Instance).Object, state);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
         var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
         var leaseServiceMock = new Mock<ILeaseService>();
         var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history, leaseServiceMock.Object);

--- a/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
+++ b/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
@@ -45,8 +45,7 @@ public class MultiScenarioLocatorTests
 
         var (state, deviceSettingsStore) = CreateStateAndStores(configLoader, mqttMock);
         var tele = new TelemetryService(mqttMock.Object);
-        var distCalc = new DistanceCalculator(new Mock<NodeSettingsStore>(mqttMock.Object, NullLogger<NodeSettingsStore>.Instance).Object, state);
-        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
         var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
         var leaseServiceMock = new Mock<ILeaseService>();
 
@@ -92,8 +91,7 @@ public class MultiScenarioLocatorTests
 
         var (state, deviceSettingsStore) = CreateStateAndStores(configLoader, mqttMock);
         var tele = new TelemetryService(mqttMock.Object);
-        var distCalc = new DistanceCalculator(new Mock<NodeSettingsStore>(mqttMock.Object, NullLogger<NodeSettingsStore>.Instance).Object, state);
-        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore, distCalc);
+        var tracker = new DeviceTracker(state, mqttMock.Object, tele, new GlobalEventDispatcher(), deviceSettingsStore);
         var history = new DeviceHistoryStore(new SQLiteAsyncConnection(":memory:"), configLoader);
         var leaseServiceMock = new Mock<ILeaseService>();
         var locator = new MultiScenarioLocator(tracker, state, mqttMock.Object, new GlobalEventDispatcher(), history, leaseServiceMock.Object);

--- a/tests/ESPresense.Companion.Tests/Optimizers/CombinedOptimizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Optimizers/CombinedOptimizerTests.cs
@@ -1,0 +1,284 @@
+using ESPresense.Models;
+using ESPresense.Optimizers;
+using ESPresense.Services;
+using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ESPresense.Companion.Tests.Optimizers;
+
+[TestFixture]
+public class CombinedOptimizerTests
+{
+    private State _state;
+    private ConfigLoader _configLoader;
+    private string _configDir;
+    private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockMqttCoordinator = new Mock<IMqttCoordinator>();
+        _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_configDir);
+
+        _configLoader = new ConfigLoader(_configDir);
+        var nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, nodeTelemetryStore, _mockNss.Object, lazyDss);
+
+        // Ensure state has an optimization config
+        _state.Config = new Config
+        {
+            Optimization = new ConfigOptimization
+            {
+                Enabled = true,
+                Limits = new Dictionary<string, double>
+                {
+                    ["absorption_min"] = 2.5,
+                    ["absorption_max"] = 3.5,
+                    ["rx_adj_rssi_min"] = -5,
+                    ["rx_adj_rssi_max"] = 30
+                }
+            }
+        };
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_configLoader != null)
+        {
+            await _configLoader.StopAsync(CancellationToken.None);
+            _configLoader.Dispose();
+        }
+
+        if (Directory.Exists(_configDir))
+        {
+            try { Directory.Delete(_configDir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Creates a measure between two OptNodes using the path-loss formula to derive RSSI
+    /// from the known distance and absorption.
+    /// RSSI = -59 + rxAdjRssi + txAdjRssi - 10 * absorption * log10(distance)
+    /// </summary>
+    private static Measure MakeMeasure(OptNode rx, OptNode tx, double trueAbsorption = 3.0)
+    {
+        double distance = rx.Location.DistanceTo(tx.Location);
+        // Invert the BFGS distance formula: dist = 10^((-59 + rxAdj + txAdj - Rssi) / (10 * abs))
+        // With rxAdj = txAdj = 0: Rssi = -59 - 10 * abs * log10(dist)
+        double rssi = -59.0 - 10.0 * trueAbsorption * Math.Log10(Math.Max(distance, 0.1));
+        return new Measure
+        {
+            Rx = rx,
+            Tx = tx,
+            Rssi = rssi,
+            RefRssi = -59.0,
+            Distance = distance
+        };
+    }
+
+    private static OptNode MakeNode(string id, double x, double y, double z, bool isNode = true, double? gMaxDb = null)
+    {
+        double gMax = gMaxDb.HasValue ? Math.Pow(10.0, gMaxDb.Value / 10.0) : 1.0;
+        bool hasDirectional = gMaxDb.HasValue;
+        return new OptNode
+        {
+            Id = id,
+            Name = id,
+            Location = new Point3D(x, y, z),
+            IsNode = isNode,
+            HasDirectionalAntenna = hasDirectional,
+            GMax = gMax
+        };
+    }
+
+    [Test]
+    public void Optimize_WithDirectionalNodes_ProducesAbsorptionsInRange()
+    {
+        // Arrange: 4 nodes in a square, 2 with directional antennas (GMaxDb = 5)
+        var nodeA = MakeNode("node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("node_b", 5, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeC = MakeNode("node_c", 5, 5, 0, isNode: true, gMaxDb: null);
+        var nodeD = MakeNode("node_d", 0, 5, 0, isNode: true, gMaxDb: null);
+
+        var os = new OptimizationSnapshot();
+        os.Measures.Add(MakeMeasure(nodeA, nodeB));
+        os.Measures.Add(MakeMeasure(nodeB, nodeA));
+        os.Measures.Add(MakeMeasure(nodeB, nodeC));
+        os.Measures.Add(MakeMeasure(nodeC, nodeB));
+        os.Measures.Add(MakeMeasure(nodeC, nodeD));
+        os.Measures.Add(MakeMeasure(nodeD, nodeC));
+        os.Measures.Add(MakeMeasure(nodeD, nodeA));
+        os.Measures.Add(MakeMeasure(nodeA, nodeD));
+        os.Measures.Add(MakeMeasure(nodeA, nodeC));
+        os.Measures.Add(MakeMeasure(nodeC, nodeA));
+
+        var optimizer = new CombinedOptimizer(_state);
+        var existingSettings = new Dictionary<string, NodeSettings>();
+
+        // Act
+        var results = optimizer.Optimize(os, existingSettings);
+
+        // Assert: all nodes should have proposed absorption values within [2.5, 3.5]
+        Assert.Multiple(() =>
+        {
+            Assert.That(results.Nodes, Contains.Key("node_a"));
+            Assert.That(results.Nodes, Contains.Key("node_b"));
+            Assert.That(results.Nodes, Contains.Key("node_c"));
+            Assert.That(results.Nodes, Contains.Key("node_d"));
+        });
+        foreach (var (id, proposed) in results.Nodes)
+        {
+            Assert.That(proposed.Absorption, Is.InRange(2.5, 3.5),
+                $"Node {id} absorption should be in [2.5, 3.5]");
+        }
+    }
+
+    [Test]
+    public void Optimize_DirectionalNodes_HaveAzimuthAndElevation()
+    {
+        // Arrange: 2 directional nodes (GMaxDb > 0) + 2 omnidirectional nodes
+        var nodeA = MakeNode("dir_node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("dir_node_b", 5, 0, 0, isNode: true, gMaxDb: 3.0);
+        var nodeC = MakeNode("omni_node_c", 5, 5, 0, isNode: true, gMaxDb: null);
+        var nodeD = MakeNode("omni_node_d", 0, 5, 0, isNode: true, gMaxDb: null);
+
+        var os = new OptimizationSnapshot();
+        os.Measures.Add(MakeMeasure(nodeA, nodeB));
+        os.Measures.Add(MakeMeasure(nodeB, nodeA));
+        os.Measures.Add(MakeMeasure(nodeA, nodeC));
+        os.Measures.Add(MakeMeasure(nodeC, nodeA));
+        os.Measures.Add(MakeMeasure(nodeB, nodeD));
+        os.Measures.Add(MakeMeasure(nodeD, nodeB));
+        os.Measures.Add(MakeMeasure(nodeC, nodeD));
+        os.Measures.Add(MakeMeasure(nodeD, nodeC));
+        os.Measures.Add(MakeMeasure(nodeA, nodeD));
+        os.Measures.Add(MakeMeasure(nodeD, nodeA));
+
+        var optimizer = new CombinedOptimizer(_state);
+        var existingSettings = new Dictionary<string, NodeSettings>();
+
+        // Act
+        var results = optimizer.Optimize(os, existingSettings);
+
+        // Assert: directional nodes should have azimuth and elevation
+        Assert.That(results.Nodes, Contains.Key("dir_node_a"));
+        Assert.That(results.Nodes, Contains.Key("dir_node_b"));
+        Assert.That(results.Nodes, Contains.Key("omni_node_c"));
+        Assert.That(results.Nodes, Contains.Key("omni_node_d"));
+
+        var proposedA = results.Nodes["dir_node_a"];
+        var proposedB = results.Nodes["dir_node_b"];
+        var proposedC = results.Nodes["omni_node_c"];
+        var proposedD = results.Nodes["omni_node_d"];
+
+        Assert.That(proposedA.Azimuth, Is.Not.Null, "Directional node_a should have Azimuth");
+        Assert.That(proposedA.Elevation, Is.Not.Null, "Directional node_a should have Elevation");
+        Assert.That(proposedA.Azimuth, Is.InRange(0.0, 360.0), "Azimuth should be [0, 360) degrees");
+        Assert.That(proposedA.Elevation, Is.InRange(-90.0, 90.0), "Elevation should be [-90, 90] degrees");
+        Assert.That(proposedB.Azimuth, Is.Not.Null, "Directional node_b should have Azimuth");
+        Assert.That(proposedB.Elevation, Is.Not.Null, "Directional node_b should have Elevation");
+        Assert.That(proposedC.Azimuth, Is.Null, "Omnidirectional node_c should NOT have Azimuth");
+        Assert.That(proposedC.Elevation, Is.Null, "Omnidirectional node_c should NOT have Elevation");
+        Assert.That(proposedD.Azimuth, Is.Null, "Omnidirectional node_d should NOT have Azimuth");
+        Assert.That(proposedD.Elevation, Is.Null, "Omnidirectional node_d should NOT have Elevation");
+    }
+
+    [Test]
+    public void Optimize_PersistsTxRefRssiFromCombinedFit()
+    {
+        var nodeA = MakeNode("node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("node_b", 5, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeC = MakeNode("node_c", 5, 5, 0, isNode: true, gMaxDb: null);
+        var nodeD = MakeNode("node_d", 0, 5, 0, isNode: true, gMaxDb: null);
+
+        var os = new OptimizationSnapshot();
+        os.Measures.Add(MakeMeasure(nodeA, nodeB));
+        os.Measures.Add(MakeMeasure(nodeB, nodeA));
+        os.Measures.Add(MakeMeasure(nodeB, nodeC));
+        os.Measures.Add(MakeMeasure(nodeC, nodeB));
+        os.Measures.Add(MakeMeasure(nodeC, nodeD));
+        os.Measures.Add(MakeMeasure(nodeD, nodeC));
+        os.Measures.Add(MakeMeasure(nodeD, nodeA));
+        os.Measures.Add(MakeMeasure(nodeA, nodeD));
+
+        var optimizer = new CombinedOptimizer(_state);
+        var results = optimizer.Optimize(os, new Dictionary<string, NodeSettings>());
+
+        foreach (var (id, proposed) in results.Nodes)
+        {
+            Assert.That(proposed.TxRefRssi, Is.Not.Null, $"Node {id} should emit a TxRef proposal");
+            Assert.That(proposed.TxRefRssi, Is.InRange(-64.0, -54.0), $"Node {id} TxRefRssi should stay near the modeled baseline");
+        }
+    }
+
+    [Test]
+    public void Optimize_InsufficientMeasurements_ReturnsEmptyResults()
+    {
+        // Arrange: only 2 measures (below the minimum of 3)
+        var nodeA = MakeNode("node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("node_b", 5, 0, 0, isNode: true, gMaxDb: 5.0);
+
+        var os = new OptimizationSnapshot();
+        os.Measures.Add(MakeMeasure(nodeA, nodeB));
+        os.Measures.Add(MakeMeasure(nodeB, nodeA));
+
+        var optimizer = new CombinedOptimizer(_state);
+        var existingSettings = new Dictionary<string, NodeSettings>();
+
+        // Act
+        var results = optimizer.Optimize(os, existingSettings);
+
+        // Assert: should return empty results
+        Assert.That(results.Nodes, Is.Empty, "Should return empty results with < 3 measurements");
+    }
+
+    [Test]
+    public void TakeOptimizationSnapshot_SetsIsNodeTrue_ForConfigNodes()
+    {
+        // Arrange: add config nodes to state
+        var configFloor = new ConfigFloor { Id = "test_floor", Name = "Test Floor" };
+        var floor = new Floor();
+        floor.Update(_state.Config!, configFloor);
+        _state.Floors["test_floor"] = floor;
+
+        var configNodeA = new ConfigNode { Name = "node_a", Point = new double[] { 0, 0, 0 }, Antenna = "external_dipole" };
+        var configNodeB = new ConfigNode { Name = "node_b", Point = new double[] { 5, 0, 0 } };
+
+        var nodeA = new Node("node_a", NodeSourceType.Config);
+        nodeA.Update(_state.Config!, configNodeA, new[] { floor });
+        _state.Nodes["node_a"] = nodeA;
+
+        var nodeB = new Node("node_b", NodeSourceType.Config);
+        nodeB.Update(_state.Config!, configNodeB, new[] { floor });
+        _state.Nodes["node_b"] = nodeB;
+
+        var rxFromTx = new RxNode
+        {
+            Tx = nodeA,
+            Rx = nodeB,
+            Distance = 5.0,
+            Rssi = -70,
+            RefRssi = -59,
+            LastHit = DateTime.UtcNow
+        };
+        nodeA.RxNodes["node_b"] = rxFromTx;
+
+        // Act
+        var snapshot = _state.TakeOptimizationSnapshot();
+
+        Assert.That(snapshot.Measures, Has.Count.EqualTo(1), "Should create measures from node-to-node data");
+        var measure = snapshot.Measures.Single();
+        Assert.That(measure.Tx.IsNode, Is.True, "Config-backed transmitter should be marked as node");
+        Assert.That(measure.Rx.IsNode, Is.True, "Config-backed receiver should be marked as node");
+        Assert.That(measure.Tx.HasDirectionalAntenna, Is.True, "Configured antenna should mark transmitter directional");
+        Assert.That(measure.Tx.GMax, Is.GreaterThan(1.0), "Directional nodes should carry antenna gain");
+    }
+}

--- a/tests/ESPresense.Companion.Tests/Optimizers/GlobalAbsorptionRxTxOptimizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Optimizers/GlobalAbsorptionRxTxOptimizerTests.cs
@@ -1,0 +1,165 @@
+using ESPresense.Models;
+using ESPresense.Optimizers;
+using ESPresense.Services;
+using MathNet.Spatial.Euclidean;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ESPresense.Companion.Tests.Optimizers;
+
+[TestFixture]
+public class GlobalAbsorptionRxTxOptimizerTests
+{
+    private State _state;
+    private ConfigLoader _configLoader;
+    private string _configDir;
+    private Mock<IMqttCoordinator> _mockMqttCoordinator;
+    private Mock<NodeSettingsStore> _mockNss;
+    private Mock<DeviceSettingsStore> _mockDss;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockMqttCoordinator = new Mock<IMqttCoordinator>();
+        _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_configDir);
+
+        _configLoader = new ConfigLoader(_configDir);
+        var nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
+        _mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, (ILogger<NodeSettingsStore>)null!);
+        _mockDss = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, (State)null!);
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => _mockDss.Object);
+        _state = new State(_configLoader, nodeTelemetryStore, _mockNss.Object, lazyDss);
+
+        _state.Config = new Config
+        {
+            Optimization = new ConfigOptimization
+            {
+                Enabled = true,
+                Limits = new Dictionary<string, double>
+                {
+                    ["absorption_min"] = 2.5,
+                    ["absorption_max"] = 3.5,
+                    ["rx_adj_rssi_min"] = -5,
+                    ["rx_adj_rssi_max"] = 30
+                }
+            }
+        };
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_configLoader != null)
+        {
+            await _configLoader.StopAsync(CancellationToken.None);
+            _configLoader.Dispose();
+        }
+
+        if (Directory.Exists(_configDir))
+        {
+            try { Directory.Delete(_configDir, true); } catch { }
+        }
+    }
+
+    private static Measure MakeMeasure(OptNode rx, OptNode tx, double trueAbsorption = 3.0)
+    {
+        double distance = rx.Location.DistanceTo(tx.Location);
+        double rssi = -59.0 - 10.0 * trueAbsorption * Math.Log10(Math.Max(distance, 0.1));
+        return new Measure
+        {
+            Rx = rx,
+            Tx = tx,
+            Rssi = rssi,
+            RefRssi = -59.0,
+            Distance = distance
+        };
+    }
+
+    private static OptNode MakeNode(string id, double x, double y, double z, bool isNode = true, double? gMaxDb = null)
+    {
+        double gMax = gMaxDb.HasValue ? Math.Pow(10.0, gMaxDb.Value / 10.0) : 1.0;
+        bool hasDirectional = gMaxDb.HasValue;
+        return new OptNode
+        {
+            Id = id,
+            Name = id,
+            Location = new Point3D(x, y, z),
+            IsNode = isNode,
+            HasDirectionalAntenna = hasDirectional,
+            GMax = gMax
+        };
+    }
+
+    [Test]
+    public void Optimize_UsesOnlyRxAdjustmentAndNoTxRef()
+    {
+        var nodeA = MakeNode("node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("node_b", 5, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeC = MakeNode("node_c", 5, 5, 0, isNode: true, gMaxDb: null);
+        var nodeD = MakeNode("node_d", 0, 5, 0, isNode: true, gMaxDb: null);
+
+        var snapshot = new OptimizationSnapshot();
+        snapshot.Measures.Add(MakeMeasure(nodeA, nodeB));
+        snapshot.Measures.Add(MakeMeasure(nodeB, nodeA));
+        snapshot.Measures.Add(MakeMeasure(nodeB, nodeC));
+        snapshot.Measures.Add(MakeMeasure(nodeC, nodeB));
+        snapshot.Measures.Add(MakeMeasure(nodeC, nodeD));
+        snapshot.Measures.Add(MakeMeasure(nodeD, nodeC));
+        snapshot.Measures.Add(MakeMeasure(nodeD, nodeA));
+        snapshot.Measures.Add(MakeMeasure(nodeA, nodeD));
+
+        var optimizer = new GlobalAbsorptionRxTxOptimizer(_state);
+        var results = optimizer.Optimize(snapshot, new Dictionary<string, NodeSettings>());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results.Nodes, Contains.Key("node_a"));
+            Assert.That(results.Nodes, Contains.Key("node_b"));
+            Assert.That(results.Nodes, Contains.Key("node_c"));
+            Assert.That(results.Nodes, Contains.Key("node_d"));
+        });
+
+        foreach (var (id, proposed) in results.Nodes)
+        {
+            Assert.That(proposed.Absorption, Is.InRange(2.5, 3.5), $"Node {id} absorption should be in range");
+            Assert.That(proposed.RxAdjRssi, Is.Not.Null, $"Node {id} should have an Rx adjustment");
+        }
+    }
+
+    [Test]
+    public void Optimize_DirectionalNodes_StillProduceAngles()
+    {
+        var nodeA = MakeNode("dir_node_a", 0, 0, 0, isNode: true, gMaxDb: 5.0);
+        var nodeB = MakeNode("dir_node_b", 5, 0, 0, isNode: true, gMaxDb: 3.0);
+        var nodeC = MakeNode("omni_node_c", 5, 5, 0, isNode: true, gMaxDb: null);
+        var nodeD = MakeNode("omni_node_d", 0, 5, 0, isNode: true, gMaxDb: null);
+
+        var snapshot = new OptimizationSnapshot();
+        snapshot.Measures.Add(MakeMeasure(nodeA, nodeB));
+        snapshot.Measures.Add(MakeMeasure(nodeB, nodeA));
+        snapshot.Measures.Add(MakeMeasure(nodeA, nodeC));
+        snapshot.Measures.Add(MakeMeasure(nodeC, nodeA));
+        snapshot.Measures.Add(MakeMeasure(nodeB, nodeD));
+        snapshot.Measures.Add(MakeMeasure(nodeD, nodeB));
+        snapshot.Measures.Add(MakeMeasure(nodeC, nodeD));
+        snapshot.Measures.Add(MakeMeasure(nodeD, nodeC));
+
+        var optimizer = new GlobalAbsorptionRxTxOptimizer(_state);
+        var results = optimizer.Optimize(snapshot, new Dictionary<string, NodeSettings>());
+
+        var proposedA = results.Nodes["dir_node_a"];
+        var proposedB = results.Nodes["dir_node_b"];
+        var proposedC = results.Nodes["omni_node_c"];
+        var proposedD = results.Nodes["omni_node_d"];
+
+        Assert.That(proposedA.Azimuth, Is.Not.Null);
+        Assert.That(proposedA.Elevation, Is.Not.Null);
+        Assert.That(proposedB.Azimuth, Is.Not.Null);
+        Assert.That(proposedB.Elevation, Is.Not.Null);
+        Assert.That(proposedC.Azimuth, Is.Null);
+        Assert.That(proposedC.Elevation, Is.Null);
+        Assert.That(proposedD.Azimuth, Is.Null);
+        Assert.That(proposedD.Elevation, Is.Null);
+    }
+}

--- a/tests/ESPresense.Companion.Tests/Optimizers/Step2LayoutTests.cs
+++ b/tests/ESPresense.Companion.Tests/Optimizers/Step2LayoutTests.cs
@@ -1,0 +1,256 @@
+using ESPresense.Optimizers;
+
+namespace ESPresense.Companion.Tests.Optimizers;
+
+[TestFixture]
+public class Step2LayoutTests
+{
+    // -----------------------------------------------------------------------
+    // VectorLength
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [TestCase(1, 4)]
+    [TestCase(3, 12)]
+    [TestCase(5, 20)]
+    public void VectorLength_Returns4TimesNodeCount(int nodeCount, int expected)
+    {
+        Assert.That(Step2Layout.VectorLength(nodeCount), Is.EqualTo(expected));
+    }
+
+    // -----------------------------------------------------------------------
+    // Block offsets
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void AbsOffset_ReturnsZero()
+    {
+        Assert.That(Step2Layout.AbsOffset(4), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void SinAzOffset_ReturnsNodeCount()
+    {
+        const int n = 4;
+        Assert.That(Step2Layout.SinAzOffset(n), Is.EqualTo(n));
+    }
+
+    [Test]
+    public void CosAzOffset_Returns2TimesNodeCount()
+    {
+        const int n = 4;
+        Assert.That(Step2Layout.CosAzOffset(n), Is.EqualTo(2 * n));
+    }
+
+    [Test]
+    public void SinElOffset_Returns3TimesNodeCount()
+    {
+        const int n = 4;
+        Assert.That(Step2Layout.SinElOffset(n), Is.EqualTo(3 * n));
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-node indices
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void AbsIndex_IsNodeIndexWithinBlock0()
+    {
+        const int n = 5;
+        for (int i = 0; i < n; i++)
+            Assert.That(Step2Layout.AbsIndex(i, n), Is.EqualTo(i));
+    }
+
+    [Test]
+    public void SinAzIndex_IsNodeIndexWithinBlock1()
+    {
+        const int n = 5;
+        for (int i = 0; i < n; i++)
+            Assert.That(Step2Layout.SinAzIndex(i, n), Is.EqualTo(n + i));
+    }
+
+    [Test]
+    public void CosAzIndex_IsNodeIndexWithinBlock2()
+    {
+        const int n = 5;
+        for (int i = 0; i < n; i++)
+            Assert.That(Step2Layout.CosAzIndex(i, n), Is.EqualTo(2 * n + i));
+    }
+
+    [Test]
+    public void SinElIndex_IsNodeIndexWithinBlock3()
+    {
+        const int n = 5;
+        for (int i = 0; i < n; i++)
+            Assert.That(Step2Layout.SinElIndex(i, n), Is.EqualTo(3 * n + i));
+    }
+
+    [Test]
+    public void AllIndices_AreUniqueAndCoverFullVector()
+    {
+        const int n = 3;
+        var indices = new HashSet<int>();
+        for (int i = 0; i < n; i++)
+        {
+            indices.Add(Step2Layout.AbsIndex(i, n));
+            indices.Add(Step2Layout.SinAzIndex(i, n));
+            indices.Add(Step2Layout.CosAzIndex(i, n));
+            indices.Add(Step2Layout.SinElIndex(i, n));
+        }
+        // Expect exactly VectorLength unique indices
+        Assert.That(indices.Count, Is.EqualTo(Step2Layout.VectorLength(n)));
+    }
+
+    // -----------------------------------------------------------------------
+    // SetAbsorptions / SetAzimuths / SetElevations round-trip
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void SetAbsorptions_PopulatesBlock0Correctly()
+    {
+        const int n = 3;
+        var x = new double[Step2Layout.VectorLength(n)];
+        double[] absorptions = [2.0, 3.5, 2.8];
+
+        Step2Layout.SetAbsorptions(x, absorptions, n);
+
+        for (int i = 0; i < n; i++)
+            Assert.That(x[Step2Layout.AbsIndex(i, n)], Is.EqualTo(absorptions[i]));
+    }
+
+    [Test]
+    public void SetAzimuths_PopulatesSinAzAndCosAzBlocks()
+    {
+        const int n = 2;
+        var x = new double[Step2Layout.VectorLength(n)];
+        double[] azimuths = [0.0, Math.PI / 4];
+
+        Step2Layout.SetAzimuths(x, azimuths, n);
+
+        for (int i = 0; i < n; i++)
+        {
+            Assert.That(x[Step2Layout.SinAzIndex(i, n)], Is.EqualTo(Math.Sin(azimuths[i])).Within(1e-12));
+            Assert.That(x[Step2Layout.CosAzIndex(i, n)], Is.EqualTo(Math.Cos(azimuths[i])).Within(1e-12));
+        }
+    }
+
+    [Test]
+    public void SetElevations_PopulatesSinElBlock()
+    {
+        const int n = 2;
+        var x = new double[Step2Layout.VectorLength(n)];
+        double[] elevations = [Math.PI / 2, Math.PI / 6];
+
+        Step2Layout.SetElevations(x, elevations, n);
+
+        for (int i = 0; i < n; i++)
+            Assert.That(x[Step2Layout.SinElIndex(i, n)], Is.EqualTo(Math.Sin(elevations[i])).Within(1e-12));
+    }
+
+    // -----------------------------------------------------------------------
+    // GetAzimuthRad / GetElevationRad round-trips
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [TestCase(0.0)]
+    [TestCase(Math.PI / 4)]
+    [TestCase(-Math.PI / 2)]
+    [TestCase(Math.PI)]
+    public void GetAzimuthRad_RoundTripsViaAtan2(double azimuthRad)
+    {
+        const int n = 1;
+        var x = new double[Step2Layout.VectorLength(n)];
+        Step2Layout.SetAzimuths(x, [azimuthRad], n);
+
+        double result = Step2Layout.GetAzimuthRad(x, 0, n);
+        Assert.That(result, Is.EqualTo(azimuthRad).Within(1e-12));
+    }
+
+    [Test]
+    [TestCase(0.0)]
+    [TestCase(Math.PI / 6)]
+    [TestCase(Math.PI / 2)]
+    [TestCase(-Math.PI / 3)]
+    public void GetElevationRad_RoundTripsViaAsin(double elevationRad)
+    {
+        const int n = 1;
+        var x = new double[Step2Layout.VectorLength(n)];
+        Step2Layout.SetElevations(x, [elevationRad], n);
+
+        double result = Step2Layout.GetElevationRad(x, 0, n);
+        Assert.That(result, Is.EqualTo(elevationRad).Within(1e-12));
+    }
+
+    // -----------------------------------------------------------------------
+    // UnitCirclePenalty
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void UnitCirclePenalty_IsZeroWhenOnUnitCircle()
+    {
+        const int n = 1;
+        var x = new double[Step2Layout.VectorLength(n)];
+        // Set azimuth=0 → sinAz=0, cosAz=1 → exactly on unit circle
+        Step2Layout.SetAzimuths(x, [0.0], n);
+
+        double penalty = Step2Layout.UnitCirclePenalty(x, 0, n);
+        Assert.That(penalty, Is.EqualTo(0.0).Within(1e-24));
+    }
+
+    [Test]
+    public void UnitCirclePenalty_IsPositiveWhenOffUnitCircle()
+    {
+        const int n = 1;
+        var x = new double[Step2Layout.VectorLength(n)];
+        // Both sinAz and cosAz set to 1 → sinAz²+cosAz²=2 ≠ 1
+        x[Step2Layout.SinAzIndex(0, n)] = 1.0;
+        x[Step2Layout.CosAzIndex(0, n)] = 1.0;
+
+        double penalty = Step2Layout.UnitCirclePenalty(x, 0, n);
+        // dev = 2 - 1 = 1; penalty = 0.1 * 1^2 = 0.1
+        Assert.That(penalty, Is.EqualTo(0.1).Within(1e-12));
+    }
+
+    [Test]
+    public void UnitCirclePenalty_UsesLambdaOf0Point1()
+    {
+        const int n = 1;
+        var x = new double[Step2Layout.VectorLength(n)];
+        // sinAz=0, cosAz=0 → sinAz²+cosAz² = 0 → dev = -1
+        // penalty = 0.1 * (-1)^2 = 0.1
+        x[Step2Layout.SinAzIndex(0, n)] = 0.0;
+        x[Step2Layout.CosAzIndex(0, n)] = 0.0;
+
+        double penalty = Step2Layout.UnitCirclePenalty(x, 0, n);
+        Assert.That(penalty, Is.EqualTo(0.1).Within(1e-12));
+    }
+
+    // -----------------------------------------------------------------------
+    // Block constants
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void BlockConstants_AreCorrect()
+    {
+        Assert.That(Step2Layout.AbsBlock, Is.EqualTo(0));
+        Assert.That(Step2Layout.SinAzBlock, Is.EqualTo(1));
+        Assert.That(Step2Layout.CosAzBlock, Is.EqualTo(2));
+        Assert.That(Step2Layout.SinElBlock, Is.EqualTo(3));
+        Assert.That(Step2Layout.BlockCount, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void DirectionalLayout_UsesOnlyDirectionalCountForAngleBlocks()
+    {
+        const int absorptionCount = 4;
+        const int directionalCount = 2;
+
+        Assert.That(Step2Layout.VectorLength(absorptionCount, directionalCount), Is.EqualTo(10));
+        Assert.That(Step2Layout.SinAzOffset(absorptionCount, directionalCount), Is.EqualTo(4));
+        Assert.That(Step2Layout.CosAzOffset(absorptionCount, directionalCount), Is.EqualTo(6));
+        Assert.That(Step2Layout.SinElOffset(absorptionCount, directionalCount), Is.EqualTo(8));
+        Assert.That(Step2Layout.SinAzIndex(1, absorptionCount, directionalCount), Is.EqualTo(5));
+        Assert.That(Step2Layout.CosAzIndex(1, absorptionCount, directionalCount), Is.EqualTo(7));
+        Assert.That(Step2Layout.SinElIndex(1, absorptionCount, directionalCount), Is.EqualTo(9));
+    }
+}

--- a/tests/ESPresense.Companion.Tests/Services/DeviceTrackerAnchorRestoreTests.cs
+++ b/tests/ESPresense.Companion.Tests/Services/DeviceTrackerAnchorRestoreTests.cs
@@ -48,14 +48,12 @@ public class DeviceTrackerAnchorRestoreTests
         _telemetryService = new TelemetryService(_mockMqttCoordinator.Object);
         _eventDispatcher = new GlobalEventDispatcher();
 
-        var distCalc = new DistanceCalculator(mockNss.Object, _state);
         _deviceTracker = new DeviceTracker(
             _state,
             _mockMqttCoordinator.Object,
             _telemetryService,
             _eventDispatcher,
-            _mockDeviceSettingsStore.Object,
-            distCalc);
+            _mockDeviceSettingsStore.Object);
     }
 
     [TearDown]

--- a/tests/ESPresense.Companion.Tests/Services/DeviceTrackerAnchorRestoreTests.cs
+++ b/tests/ESPresense.Companion.Tests/Services/DeviceTrackerAnchorRestoreTests.cs
@@ -27,6 +27,9 @@ public class DeviceTrackerAnchorRestoreTests
     {
         _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
         Directory.CreateDirectory(_configDir);
+        // Write a minimal config with no floors/nodes so LoadConfig is idempotent
+        // even if the ConfigChanged race condition triggers a double-call.
+        File.WriteAllText(Path.Combine(_configDir, "config.yaml"), "mqtt:\n  host: localhost\n");
 
         _configLoader = new ConfigLoader(_configDir);
         var supervisorLoader = new SupervisorConfigLoader(NullLogger<SupervisorConfigLoader>.Instance);
@@ -34,17 +37,25 @@ public class DeviceTrackerAnchorRestoreTests
         _mockMqttCoordinator.Setup(m => m.EnqueueAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).Returns(Task.CompletedTask);
 
         _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
-        _state = new State(_configLoader, _nodeTelemetryStore);
+        var mockNss = new Mock<NodeSettingsStore>(_mockMqttCoordinator.Object, NullLogger<NodeSettingsStore>.Instance);
+        // Use a closure so that lazyDss can be passed to State before _mockDeviceSettingsStore is created,
+        // while still supplying the correct State instance to DeviceSettingsStore.
+        Mock<DeviceSettingsStore>? dssRef = null;
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => dssRef!.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore, mockNss.Object, lazyDss);
         _mockDeviceSettingsStore = new Mock<DeviceSettingsStore>(_mockMqttCoordinator.Object, _state);
+        dssRef = _mockDeviceSettingsStore;
         _telemetryService = new TelemetryService(_mockMqttCoordinator.Object);
         _eventDispatcher = new GlobalEventDispatcher();
 
+        var distCalc = new DistanceCalculator(mockNss.Object, _state);
         _deviceTracker = new DeviceTracker(
             _state,
             _mockMqttCoordinator.Object,
             _telemetryService,
             _eventDispatcher,
-            _mockDeviceSettingsStore.Object);
+            _mockDeviceSettingsStore.Object,
+            distCalc);
     }
 
     [TearDown]

--- a/tests/ESPresense.Companion.Tests/Services/McpResourcesTests.cs
+++ b/tests/ESPresense.Companion.Tests/Services/McpResourcesTests.cs
@@ -14,7 +14,10 @@ public class McpResourcesTests
         var mqtt = new Mock<IMqttCoordinator>();
         var nodeSettingsStore = new NodeSettingsStore(mqtt.Object, Mock.Of<Microsoft.Extensions.Logging.ILogger<NodeSettingsStore>>());
         var nodeTelemetryStore = new NodeTelemetryStore(mqtt.Object);
-        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore);
+        DeviceSettingsStore? deviceSettingsStore = null;
+        var lazyDss = new Lazy<DeviceSettingsStore>(() => deviceSettingsStore!);
+        var state = new State(new Mock<ConfigLoader>("test-config-dir").Object, nodeTelemetryStore, nodeSettingsStore, lazyDss);
+        deviceSettingsStore = new DeviceSettingsStore(mqtt.Object, state);
         var firmwareUpdateJobs = new FirmwareUpdateJobService(
             nodeSettingsStore,
             nodeTelemetryStore,
@@ -27,7 +30,7 @@ public class McpResourcesTests
             new Mock<ConfigLoader>("test-config-dir").Object,
             nodeSettingsStore,
             nodeTelemetryStore,
-            new DeviceSettingsStore(mqtt.Object, state),
+            deviceSettingsStore,
             telemetryService,
             firmwareUpdateJobs,
             Mock.Of<IMapper>());


### PR DESCRIPTION
## Summary

Adds directional antenna gain modeling to localization and optimization, with follow-up fixes from review comments.

Key changes:
- add antenna-aware enrichment to multilateralization using configured antenna profiles plus saved azimuth/elevation calibration
- keep uncalibrated directional nodes isotropic until both angles are available
- run enrichment cleanup after scoring in a guaranteed `finally` path
- harden Gauss-Newton, MLE, and Nelder-Mead around convergence reporting, unbounded floors, and simplex initialization
- tighten the combined optimizer so step-2 reports the correct error and only allocates angle parameters for directional receivers
- keep simulation and test wiring aligned with production by reusing the same `NodeSettingsStore` and `DeviceSettingsStore` instances

## Configuration

Directional antennas are configured through antenna profiles.

Built-in profiles are available in `config.example.yaml`, and nodes reference them by name:

```yaml
nodes:
  - name: Kitchen
    point: [8, 6.5, 1]
    floors: ["first"]
    antenna: pcb_ifa
```

Custom profiles can also be defined with `g_max_db`, `pattern_exponent`, and `back_loss_db`, then referenced from `nodes[*].antenna`.

Behavior notes:
- nodes without an antenna profile remain isotropic
- nodes with an antenna profile also remain isotropic until azimuth and elevation calibration values are saved
- azimuth/elevation are companion-side calibration values and are not pushed back to firmware

## Implementation Notes

- runtime distance correction now uses calibrated antenna gain during iterative solving, but Pearson/confidence scoring sees the same enriched distances used by the solver
- Gauss-Newton now reports non-convergence when it exhausts iterations instead of always marking the solve as converged
- MLE and Nelder-Mead now tolerate unbounded floors and avoid degenerate simplex seeds
- the combined optimizer now uses a smaller step-2 vector by skipping dead angle dimensions for isotropic receivers
- phase-2 antenna optimization persists its objective value so downstream comparisons use the final error, not the phase-1 error

## Test Plan

- [x] `dotnet test`
- [x] 24 Playwright tests passing
- [x] 188 backend tests passing
- [x] targeted locator/optimizer regression coverage updated for the review fixes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antenna profile system with built-in presets and custom profiles
  * Per-node azimuth/elevation calibration and antenna-aware gain correction
  * Settings view in calibration UI showing antenna, azimuth, elevation, absorption, and RX adj RSSI

* **Improvements**
  * Localization/optimization updated to use directional-antenna gain corrections and iterative gain-correction flow
  * Combined multi-phase optimizer for absorptions and antenna angles for improved accuracy

* **Documentation**
  * Example config updated with antenna profiles and node antenna references

* **Tests**
  * Expanded test coverage for directional antennas, optimizers, and calibration snapshot behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->