### PR TITLE
feat(simulation): expose ILocate as stdin/stdout JSON CLI

### DIFF
--- a/tests/ESPresense.Companion.Simulation/LocateCli.cs
+++ b/tests/ESPresense.Companion.Simulation/LocateCli.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ESPresense.Locators;
+using ESPresense.Models;
+using ESPresense.Simulation.Tests;
+
+namespace ESPresense.Simulation;
+
+/// <summary>
+/// stdin/stdout JSON wrapper around the production ILocate implementations.
+/// See README.md for the request/response shape.
+/// </summary>
+public static class LocateCli
+{
+    public static int Run(TextReader stdin, TextWriter stdout, TextWriter stderr)
+    {
+        string raw;
+        try
+        {
+            raw = stdin.ReadToEnd();
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine($"Failed to read stdin: {ex.Message}");
+            return 2;
+        }
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            stderr.WriteLine("Empty stdin. Pipe a JSON request describing floor_bounds, locator, stations and distances.");
+            return 2;
+        }
+
+        LocateRequest? req;
+        try
+        {
+            req = JsonSerializer.Deserialize<LocateRequest>(raw, JsonOpts);
+        }
+        catch (JsonException ex)
+        {
+            stderr.WriteLine($"Invalid request JSON: {ex.Message}");
+            return 2;
+        }
+
+        if (req == null)
+        {
+            stderr.WriteLine("Request deserialized to null.");
+            return 2;
+        }
+
+        if (!TryValidate(req, out var validationError))
+        {
+            stderr.WriteLine(validationError);
+            return 2;
+        }
+
+        try
+        {
+            var response = Solve(req!);
+            stdout.WriteLine(JsonSerializer.Serialize(response, JsonOpts));
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            stderr.WriteLine($"Locate failed: {ex.GetType().Name}: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static bool TryValidate(LocateRequest req, out string error)
+    {
+        if (req.FloorBounds == null || req.FloorBounds.Length != 2)
+        {
+            error = "floor_bounds must be a 2-element array of [x,y,z] points.";
+            return false;
+        }
+        foreach (var pt in req.FloorBounds)
+        {
+            if (pt == null || pt.Length < 3)
+            {
+                error = "floor_bounds points must each have at least 3 components (x,y,z).";
+                return false;
+            }
+        }
+        if (string.IsNullOrWhiteSpace(req.Locator))
+        {
+            error = "locator is required (NelderMead | GaussNewton | BFGS | MLE).";
+            return false;
+        }
+        if (req.Stations == null || req.Stations.Count == 0)
+        {
+            error = "stations is required and must be non-empty.";
+            return false;
+        }
+        if (req.Distances == null || req.Distances.Count == 0)
+        {
+            error = "distances is required and must be non-empty.";
+            return false;
+        }
+        error = string.Empty;
+        return true;
+    }
+
+    private static LocateResponse Solve(LocateRequest req)
+    {
+        // Build a minimal in-memory Floor/State/Device wired up the same way
+        // the existing MultilaterationSimulator does it.
+        var configFloor = new ConfigFloor
+        {
+            Name = "harness",
+            Bounds = new[]
+            {
+                new[] { req.FloorBounds![0][0], req.FloorBounds[0][1], req.FloorBounds[0][2] },
+                new[] { req.FloorBounds![1][0], req.FloorBounds[1][1], req.FloorBounds[1][2] }
+            }
+        };
+        var config = new Config { Floors = new[] { configFloor } };
+
+        var floor = new Floor();
+        floor.Update(config, configFloor);
+
+        var configLoader = new MockConfigLoader(config);
+        var nodeTelemetryStore = new MockNodeTelemetryStore();
+        var state = new State(configLoader, nodeTelemetryStore);
+
+        var device = new Device("harness-device", "harness", TimeSpan.FromSeconds(30));
+        state.Devices[device.Id] = device;
+
+        var nodesById = new Dictionary<string, Node>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in req.Stations!)
+        {
+            if (string.IsNullOrWhiteSpace(s.Id))
+                throw new InvalidOperationException("station.id is required for each station.");
+
+            var node = new Node(s.Id, NodeSourceType.Config);
+            var configNode = new ConfigNode
+            {
+                Name = s.Id,
+                Id = s.Id,
+                Point = new[] { s.X, s.Y, s.Z }
+            };
+            node.Update(config, configNode, new[] { floor });
+            nodesById[s.Id] = node;
+            state.Nodes[s.Id] = node;
+        }
+
+        var now = DateTime.UtcNow;
+        foreach (var d in req.Distances!)
+        {
+            if (string.IsNullOrWhiteSpace(d.StationId))
+                throw new InvalidOperationException("distance.station_id is required.");
+            if (!nodesById.TryGetValue(d.StationId, out var node))
+                throw new InvalidOperationException($"distance.station_id '{d.StationId}' has no matching station entry.");
+
+            device.Nodes[node.Id] = new DeviceToNode(device, node)
+            {
+                Distance = Math.Max(0.1, d.DistanceM),
+                LastHit = now
+            };
+        }
+
+        ILocate locator = req.Locator!.Trim().ToLowerInvariant() switch
+        {
+            "neldermead" or "nelder-mead" or "nm" => new NelderMeadMultilateralizer(device, floor, state),
+            "gaussnewton" or "gauss-newton" or "gn" => new GaussNewtonMultilateralizer(device, floor, state),
+            "bfgs" => new BfgsMultilateralizer(device, floor, state),
+            "mle" => new MLEMultilateralizer(device, floor, state),
+            _ => throw new InvalidOperationException(
+                $"unknown locator '{req.Locator}'. Supported: NelderMead, GaussNewton, BFGS, MLE.")
+        };
+
+        var scenario = new Scenario(config, locator, "harness")
+        {
+            Confidence = 0
+        };
+
+        bool moved = locator.Locate(scenario);
+
+        var loc = scenario.Location;
+        return new LocateResponse
+        {
+            X = loc.X,
+            Y = loc.Y,
+            Z = loc.Z,
+            Confidence = scenario.Confidence,
+            Fixes = scenario.Fixes,
+            Error = scenario.Error,
+            Iterations = scenario.Iterations,
+            ReasonForExit = scenario.ReasonForExit.ToString(),
+            Moved = moved
+        };
+    }
+
+    private sealed class LocateRequest
+    {
+        [JsonPropertyName("floor_bounds")]
+        public double[][]? FloorBounds { get; set; }
+
+        [JsonPropertyName("locator")]
+        public string? Locator { get; set; }
+
+        [JsonPropertyName("stations")]
+        public List<Station>? Stations { get; set; }
+
+        [JsonPropertyName("distances")]
+        public List<DistanceReading>? Distances { get; set; }
+    }
+
+    private sealed class Station
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("x")]
+        public double X { get; set; }
+
+        [JsonPropertyName("y")]
+        public double Y { get; set; }
+
+        [JsonPropertyName("z")]
+        public double Z { get; set; }
+    }
+
+    private sealed class DistanceReading
+    {
+        [JsonPropertyName("station_id")]
+        public string? StationId { get; set; }
+
+        [JsonPropertyName("distance_m")]
+        public double DistanceM { get; set; }
+    }
+
+    private sealed class LocateResponse
+    {
+        [JsonPropertyName("x")]
+        public double X { get; set; }
+
+        [JsonPropertyName("y")]
+        public double Y { get; set; }
+
+        [JsonPropertyName("z")]
+        public double Z { get; set; }
+
+        [JsonPropertyName("confidence")]
+        public int? Confidence { get; set; }
+
+        [JsonPropertyName("fixes")]
+        public int? Fixes { get; set; }
+
+        [JsonPropertyName("error")]
+        public double? Error { get; set; }
+
+        [JsonPropertyName("iterations")]
+        public int? Iterations { get; set; }
+
+        [JsonPropertyName("reason_for_exit")]
+        public string? ReasonForExit { get; set; }
+
+        [JsonPropertyName("moved")]
+        public bool Moved { get; set; }
+    }
+}

--- a/tests/ESPresense.Companion.Simulation/Program.cs
+++ b/tests/ESPresense.Companion.Simulation/Program.cs
@@ -92,13 +92,21 @@ class Program
             return;
         }
 
+        if (args.Length > 0 && args[0] == "locate")
+        {
+            int exit = LocateCli.Run(Console.In, Console.Out, Console.Error);
+            Environment.Exit(exit);
+            return;
+        }
+
         Console.WriteLine("ESPresense Multilateration Algorithm Comparison");
         Console.WriteLine("================================================");
         Console.WriteLine("Testing actual ILocate implementations from ESPresense.Companion\n");
         Console.WriteLine($"Accurate run threshold: <= {SuccessThresholdMeters:F1}m 2D error\n");
         Console.WriteLine("Tips:");
         Console.WriteLine("  Run 'dotnet run weightings' to compare weighting schemes");
-        Console.WriteLine("  Run 'dotnet run multifloor' to test multi-floor confidence\n");
+        Console.WriteLine("  Run 'dotnet run multifloor' to test multi-floor confidence");
+        Console.WriteLine("  Pipe a JSON request to 'dotnet run locate' to call ILocate as a CLI\n");
         
         // Test scenarios
         var scenarios = new (string Name, Action<MultilaterationSimulator> Configure)[]

--- a/tests/ESPresense.Companion.Simulation/README.md
+++ b/tests/ESPresense.Companion.Simulation/README.md
@@ -1,6 +1,9 @@
 # ESPresense Multilateration Simulator
 
 Compares real `ILocate` implementations from `ESPresense.Companion` under controlled conditions.
+Also exposes those same implementations as a stdin/stdout JSON CLI so external accuracy
+harnesses (e.g. firmware QA) can call them without taking a process-level dependency on
+the full Companion service stack.
 
 ## Quick Start
 
@@ -16,6 +19,56 @@ Or from this directory:
 cd tests/ESPresense.Companion.Simulation
 dotnet run
 ```
+
+## Subcommands
+
+- (no args) — Monte-Carlo comparison across scenarios and node layouts.
+- `weightings` — compare weighting schemes for the chosen locator.
+- `multifloor` — multi-floor confidence regression test.
+- `locate` — read one JSON solve request on stdin, write one solve result on stdout.
+
+### `locate` CLI
+
+Reads a single JSON request describing the floor, the chosen locator, the stations,
+and the per-station distance measurements. Emits a single JSON solve on stdout.
+
+```bash
+dotnet run --project tests/ESPresense.Companion.Simulation -- locate \
+  < tests/ESPresense.Companion.Simulation/locate-example.json
+```
+
+Request shape (snake_case):
+
+```json
+{
+  "floor_bounds": [[0, 0, 0], [12, 12, 3]],
+  "locator": "NelderMead",
+  "stations": [{ "id": "n0", "x": 0, "y": 0, "z": 1 }],
+  "distances": [{ "station_id": "n0", "distance_m": 7.07 }]
+}
+```
+
+Supported `locator` values: `NelderMead`, `GaussNewton`, `BFGS`, `MLE`
+(case-insensitive; `nelder-mead` and `gauss-newton` also accepted).
+`NadarayaWatson` is intentionally not exposed here because it depends on
+node telemetry data that an offline harness does not have.
+
+Response shape:
+
+```json
+{
+  "x": 6.0, "y": 6.0, "z": 1.0,
+  "confidence": 7,
+  "fixes": 4,
+  "error": 0.0123,
+  "iterations": 42,
+  "reason_for_exit": "BoundTolerance",
+  "moved": true
+}
+```
+
+Exit codes: `0` solve completed (whether or not `moved` is true);
+`1` locator threw; `2` invalid or empty input.
 
 ## What It Tests
 

--- a/tests/ESPresense.Companion.Simulation/locate-example.json
+++ b/tests/ESPresense.Companion.Simulation/locate-example.json
@@ -1,0 +1,16 @@
+{
+  "floor_bounds": [[0, 0, 0], [12, 12, 3]],
+  "locator": "NelderMead",
+  "stations": [
+    { "id": "n0", "x": 0,  "y": 0,  "z": 1 },
+    { "id": "n1", "x": 12, "y": 0,  "z": 1 },
+    { "id": "n2", "x": 12, "y": 12, "z": 1 },
+    { "id": "n3", "x": 0,  "y": 12, "z": 1 }
+  ],
+  "distances": [
+    { "station_id": "n0", "distance_m": 7.07 },
+    { "station_id": "n1", "distance_m": 7.07 },
+    { "station_id": "n2", "distance_m": 7.07 },
+    { "station_id": "n3", "distance_m": 7.07 }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `locate` subcommand to the existing `ESPresense.Companion.Simulation` test project that reads one JSON solve request from stdin, runs the production `ILocate` (NelderMead / GaussNewton / BFGS / MLE), and writes the solve result as JSON to stdout.

This unblocks the firmware accuracy harness (ESPresense/ESPresense — `tools/accuracy_harness/`) which currently ships a documented Nelder-Mead stub solver because the real implementations live behind the .NET process boundary. With this CLI, that harness can `subprocess.run(["dotnet", ...])` per sample and compare against the actual algorithms Companion runs in production.

## What's in the diff

- `tests/ESPresense.Companion.Simulation/LocateCli.cs` — the wrapper. Reuses the same `MockConfigLoader` + `MockNodeTelemetryStore` plumbing the existing `MultilaterationSimulator` uses.
- `tests/ESPresense.Companion.Simulation/Program.cs` — dispatch `locate` arg.
- `tests/ESPresense.Companion.Simulation/locate-example.json` — request fixture.
- `tests/ESPresense.Companion.Simulation/README.md` — request/response shape, supported locators.

No changes to anything under `src/`. NadarayaWatson is intentionally not exposed because it depends on node telemetry an offline harness does not have.

## Request / response shape

```json
{
  "floor_bounds": [[0,0,0],[12,12,3]],
  "locator": "NelderMead",
  "stations":  [{"id":"n0","x":0,"y":0,"z":1}],
  "distances": [{"station_id":"n0","distance_m":7.07}]
}
```

```json
{ "x":..., "y":..., "z":..., "confidence":..., "fixes":..., "error":..., "iterations":..., "reason_for_exit":"...", "moved":true }
```

## Test plan

- [ ] `dotnet build` (CI)
- [ ] `dotnet run --project tests/ESPresense.Companion.Simulation -- locate < tests/ESPresense.Companion.Simulation/locate-example.json` returns a valid JSON solve for each of NelderMead, GaussNewton, BFGS, MLE
- [ ] Existing simulator subcommands (`weightings`, `multifloor`, default) still behave as before
- [ ] Once merged, swap `tools/accuracy_harness/solver.py::solve()` to a `subprocess.run(["dotnet", ...])` shim and re-baseline accuracy numbers

Closes ESPA-26.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `locate` CLI subcommand for running multilateration simulations via JSON stdin/stdout with support for multiple locator algorithms (NelderMead, GaussNewton, BFGS, MLE), returning position coordinates and confidence metrics.

* **Documentation**
  * Updated documentation with locate subcommand specifications, JSON format details, and exit code semantics.
  * Added example JSON fixture for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->