### PR TITLE
ci(accuracy): publish accuracy report to log + artifact

### DIFF
--- a/.github/workflows/accuracy-harness.yml
+++ b/.github/workflows/accuracy-harness.yml
@@ -7,6 +7,7 @@ name: Accuracy harness
 #   - and this workflow.
 # This is NOT a general "did the build break" gate (that is ci.yml).
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -54,6 +55,25 @@ jobs:
         # Release config bypasses the SPA install in src/ESPresense.Companion.csproj,
         # which has no business running for the accuracy gate.
         run: dotnet build -c Release tests/ESPresense.Companion.Simulation/ESPresense.Simulation.csproj
+
+      - name: Generate accuracy report
+        run: |
+          mkdir -p accuracy-report
+          dotnet run --no-build -c Release --project tests/ESPresense.Companion.Simulation -- \
+            accuracy baseline \
+            --output accuracy-report/accuracy-report.json \
+            --markdown accuracy-report/accuracy-report.md
+          echo "## Multilateration accuracy report" >> "$GITHUB_STEP_SUMMARY"
+          cat accuracy-report/accuracy-report.md >> "$GITHUB_STEP_SUMMARY"
+          cat accuracy-report/accuracy-report.md
+
+      - name: Upload accuracy report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: accuracy-report-${{ github.sha }}
+          path: accuracy-report/
+          retention-days: 90
 
       - name: Run accuracy check (±5% tolerance)
         run: |


### PR DESCRIPTION
## Why

The accuracy harness added in #1582 runs in CI via `accuracy-harness.yml`, but the workflow only executes the `accuracy check` regression gate. On success that prints a single line (`Baseline match within ±5% tolerance.`) and uploads nothing — so the actual positioning numbers (median/p95/mean error, room mis-id, outage sweep) are never visible in a CI run, and there's nothing to compare across commits.

## What

`accuracy-harness.yml`:

- **Generate accuracy report** — runs `accuracy baseline` (same defaults/seed as the checked-in baseline) into a scratch dir, renders the Markdown table into the job **Summary** (and the log).
- **Upload artifact** — uploads the JSON + Markdown as `accuracy-report-<sha>` (`if: always()`, 90-day retention) so each commit's numbers are downloadable and diffable across runs, even when the gate fails on drift.
- **`workflow_dispatch`** — regenerate numbers on demand without touching a locator path.
- The existing `accuracy check` regression gate is unchanged.

No harness/C# changes — the harness already supported this via `accuracy baseline --output/--markdown`, and the run is deterministic (`--seed 20260530`).

## Verification

- `dotnet build -c Release` of the simulation project succeeds.
- `accuracy baseline` reproduces the checked-in `baseline-v1.md` exactly (diagonal_walk median 0.60m / p95 1.33m; living_to_bedroom median 0.60m / p95 1.61m), confirming artifacts are deterministic and diffable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now supports manual triggering and generates simulation accuracy reports in JSON and Markdown.
  * Markdown summaries are appended to the run summary and printed in logs.
  * Accuracy reports are uploaded as a downloadable artifact named by commit and retained for 90 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->