### PR TITLE
Fix optimizer absorption degeneracy (legacy clobber + active-mode bound railing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ test-results
 
 # Oh My ClaudeCode
 .omc/
+
+# Playwright CLI
+.playwright-cli/

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -174,11 +174,8 @@ namespace ESPresense.Models
         [YamlMember(Alias = "limits")] public Dictionary<string, double> Limits { get; set; } = new();
         [YamlMember(Alias = "weights")] public Dictionary<string, double> Weights { get; set; } = new();
 
-        // Indoor effective path-loss exponents commonly run 3.5-4.5 once body shadowing and
-        // appliances are present, well above the free-space ~2. A [2, 4] default silently
-        // clamps most real nodes at the ceiling, so default to a wider, realistic range.
         [YamlIgnore] public double AbsorptionMin => Limits.TryGetValue("absorption_min", out var val) ? val : 2;
-        [YamlIgnore] public double AbsorptionMax => Limits.TryGetValue("absorption_max", out var val) ? val : 5;
+        [YamlIgnore] public double AbsorptionMax => Limits.TryGetValue("absorption_max", out var val) ? val : 4;
         [YamlIgnore] public double TxRefRssiMin => Limits.TryGetValue("tx_ref_rssi_min", out var val) ? val : -70;
         [YamlIgnore] public double TxRefRssiMax => Limits.TryGetValue("tx_ref_rssi_max", out var val) ? val : -50;
         [YamlIgnore] public double RxAdjRssiMin => Limits.TryGetValue("rx_adj_rssi_min", out var val) ? val : -5;

--- a/src/Models/Config.cs
+++ b/src/Models/Config.cs
@@ -174,8 +174,11 @@ namespace ESPresense.Models
         [YamlMember(Alias = "limits")] public Dictionary<string, double> Limits { get; set; } = new();
         [YamlMember(Alias = "weights")] public Dictionary<string, double> Weights { get; set; } = new();
 
+        // Indoor effective path-loss exponents commonly run 3.5-4.5 once body shadowing and
+        // appliances are present, well above the free-space ~2. A [2, 4] default silently
+        // clamps most real nodes at the ceiling, so default to a wider, realistic range.
         [YamlIgnore] public double AbsorptionMin => Limits.TryGetValue("absorption_min", out var val) ? val : 2;
-        [YamlIgnore] public double AbsorptionMax => Limits.TryGetValue("absorption_max", out var val) ? val : 4;
+        [YamlIgnore] public double AbsorptionMax => Limits.TryGetValue("absorption_max", out var val) ? val : 5;
         [YamlIgnore] public double TxRefRssiMin => Limits.TryGetValue("tx_ref_rssi_min", out var val) ? val : -70;
         [YamlIgnore] public double TxRefRssiMax => Limits.TryGetValue("tx_ref_rssi_max", out var val) ? val : -50;
         [YamlIgnore] public double RxAdjRssiMin => Limits.TryGetValue("rx_adj_rssi_min", out var val) ? val : -5;

--- a/src/Optimizers/GlobalAbsorptionRxTxOptimizer.cs
+++ b/src/Optimizers/GlobalAbsorptionRxTxOptimizer.cs
@@ -301,30 +301,64 @@ public class GlobalAbsorptionRxTxOptimizer : IOptimizer
             var result = solver.FindMinimum(objectiveFunction, lowerBound, upperBound, initialGuess);
 
             // Get the optimized global absorption value
-            double globalAbsorptionValue = result.MinimizingPoint[globalAbsorptionIndex];
+            var final = result.MinimizingPoint;
+            double globalAbsorptionValue = final[globalAbsorptionIndex];
             globalAbsorptionValue = Math.Max(optimization.AbsorptionMin, Math.Min(globalAbsorptionValue, optimization.AbsorptionMax));
+
+            // Per-node fit quality: weighted RMS of the (asymmetric) RSSI error over each node's own
+            // measurements, using the final fitted parameters. Replaces storing the single global
+            // objective value on every node, which made every node's Error look identical.
+            var rxErrorSum = new Dictionary<string, double>();
+            var rxWeightSum = new Dictionary<string, double>();
+            var txErrorSum = new Dictionary<string, double>();
+            var txWeightSum = new Dictionary<string, double>();
+
+            foreach (var node in allRxNodes)
+            {
+                if (node.Rx?.Location == null || node.Tx?.Location == null) continue;
+
+                double rxAdjRssi = final[rxIndexMap[node.Rx.Id]];
+                double txRefRssi = final[txIndexMap[node.Tx.Id]];
+                double mapDistance = node.Rx.Location.DistanceTo(node.Tx.Location);
+                if (mapDistance <= 0) mapDistance = 0.1;
+
+                double predictedRssi = txRefRssi - 10 * globalAbsorptionValue * Math.Log10(mapDistance);
+                double diff = predictedRssi - node.GetAdjustedRssi(rxAdjRssi);
+                double err = diff < 0
+                    ? Math.Min(AsymmetricErrorFactor * Math.Pow(diff, 2), CappedError)
+                    : Math.Min(Math.Pow(diff, 2), CappedError);
+                double weight = nodeWeights[node];
+
+                rxErrorSum[node.Rx.Id] = rxErrorSum.GetValueOrDefault(node.Rx.Id) + weight * err;
+                rxWeightSum[node.Rx.Id] = rxWeightSum.GetValueOrDefault(node.Rx.Id) + weight;
+                txErrorSum[node.Tx.Id] = txErrorSum.GetValueOrDefault(node.Tx.Id) + weight * err;
+                txWeightSum[node.Tx.Id] = txWeightSum.GetValueOrDefault(node.Tx.Id) + weight;
+            }
+
+            double? PerNodeError(Dictionary<string, double> errSum, Dictionary<string, double> wSum, string id)
+                => wSum.TryGetValue(id, out var w) && w > 0 ? Math.Sqrt(errSum[id] / w) : null;
 
             // Process Rx node results
             foreach (var rxId in uniqueRxIds)
             {
-                double rxAdjRssi = result.MinimizingPoint[rxIndexMap[rxId]];
+                double rxAdjRssi = final[rxIndexMap[rxId]];
                 rxAdjRssi = Math.Max(optimization.RxAdjRssiMin, Math.Min(rxAdjRssi, optimization.RxAdjRssiMax));
 
                 var n = or.Nodes.GetOrAdd(rxId);
                 n.RxAdjRssi = rxAdjRssi;
                 n.Absorption = globalAbsorptionValue;
-                n.Error = result.FunctionInfoAtMinimum.Value;
+                n.Error = PerNodeError(rxErrorSum, rxWeightSum, rxId);
             }
 
             // Process Tx node results
             foreach (var txId in uniqueTxIds)
             {
-                double txRefRssi = result.MinimizingPoint[txIndexMap[txId]];
+                double txRefRssi = final[txIndexMap[txId]];
                 txRefRssi = Math.Max(optimization.TxRefRssiMin, Math.Min(txRefRssi, optimization.TxRefRssiMax));
 
                 var n = or.Nodes.GetOrAdd(txId);
                 n.TxRefRssi = txRefRssi;
-                n.Error = result.FunctionInfoAtMinimum.Value;
+                n.Error = PerNodeError(txErrorSum, txWeightSum, txId);
             }
 
             // Log the optimization results

--- a/src/Optimizers/OptimizationRunner.cs
+++ b/src/Optimizers/OptimizationRunner.cs
@@ -203,7 +203,7 @@ internal class OptimizationRunner : BackgroundService
             railed.Add($"TxRefRssi={result.TxRefRssi:0} ({txEdge} {(txEdge == "min" ? optimization.TxRefRssiMin : optimization.TxRefRssiMax):0})");
 
         if (railed.Count > 0)
-            Log.Warning("Node {0} railed to optimization bound(s): {1}. Consider widening the corresponding limit; a clamped value is not a true fit.",
+            Log.Warning("Node {0} railed to optimization bound(s): {1}. A clamped value is not a true fit — review the limit or the node (note: a wider absorption range does not necessarily improve positioning).",
                 id, string.Join(", ", railed));
     }
 

--- a/src/Optimizers/OptimizationRunner.cs
+++ b/src/Optimizers/OptimizationRunner.cs
@@ -158,6 +158,8 @@ internal class OptimizationRunner : BackgroundService
                             Log.Information("Applied {0,-20}: Absorption={1:0.00}, RxAdj={2:00}, TxAdj={3:00}, Error={4}",
                                 id, result.Absorption, result.RxAdjRssi, result.TxRefRssi, result.Error);
 
+                            WarnIfRailed(id, result, optimization);
+
                             var nodeSettings = _nsd.Get(id);
                             if (result.Absorption != null) nodeSettings.Calibration.Absorption = result.Absorption;
                             if (result.RxAdjRssi != null) nodeSettings.Calibration.RxAdjRssi = (int?)Math.Round(result.RxAdjRssi.Value);
@@ -182,5 +184,35 @@ internal class OptimizationRunner : BackgroundService
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
             }
         }
+    }
+
+    // A value that converges exactly onto a configured min/max bound means the optimizer
+    // wanted to go further but was clamped — the calibration is being artificially pinned
+    // (the "all nodes stuck at the same absorption" degeneracy). Surface it so users know to
+    // widen the relevant limit rather than silently trusting a railed value.
+    private static void WarnIfRailed(string id, ProposedValues result, ConfigOptimization optimization)
+    {
+        const double eps = 1e-3;
+        var railed = new List<string>();
+
+        if (AtBound(result.Absorption, optimization.AbsorptionMin, optimization.AbsorptionMax, eps, out var absEdge))
+            railed.Add($"Absorption={result.Absorption:0.00} ({absEdge} {(absEdge == "min" ? optimization.AbsorptionMin : optimization.AbsorptionMax):0.0})");
+        if (AtBound(result.RxAdjRssi, optimization.RxAdjRssiMin, optimization.RxAdjRssiMax, eps, out var rxEdge))
+            railed.Add($"RxAdjRssi={result.RxAdjRssi:0} ({rxEdge} {(rxEdge == "min" ? optimization.RxAdjRssiMin : optimization.RxAdjRssiMax):0})");
+        if (AtBound(result.TxRefRssi, optimization.TxRefRssiMin, optimization.TxRefRssiMax, eps, out var txEdge))
+            railed.Add($"TxRefRssi={result.TxRefRssi:0} ({txEdge} {(txEdge == "min" ? optimization.TxRefRssiMin : optimization.TxRefRssiMax):0})");
+
+        if (railed.Count > 0)
+            Log.Warning("Node {0} railed to optimization bound(s): {1}. Consider widening the corresponding limit; a clamped value is not a true fit.",
+                id, string.Join(", ", railed));
+    }
+
+    private static bool AtBound(double? value, double min, double max, double eps, out string edge)
+    {
+        edge = string.Empty;
+        if (value == null) return false;
+        if (value.Value <= min + eps) { edge = "min"; return true; }
+        if (value.Value >= max - eps) { edge = "max"; return true; }
+        return false;
     }
 }

--- a/src/Optimizers/PerNodeAbsorptionRxTx.cs
+++ b/src/Optimizers/PerNodeAbsorptionRxTx.cs
@@ -238,13 +238,45 @@ public class PerNodeAbsorptionRxTx : IOptimizer
             // Use the bounded BFGS solver
             var solver = new BfgsBMinimizer(1e-8, 1e-8, 1e-8, 10000);
             var result = solver.FindMinimum(objectiveFunction, lowerBound, upperBound, initialGuess);
+            var final = result.MinimizingPoint;
+
+            // Per-node fit quality: weighted RMS of the (asymmetric) distance error over each
+            // node's own measurements, using the final fitted parameters. This replaces storing
+            // the single global objective value on every node, which made every node's Error look
+            // identical regardless of how well that node actually fit.
+            var rxErrorSum = new Dictionary<string, double>();
+            var rxWeightSum = new Dictionary<string, double>();
+            var txErrorSum = new Dictionary<string, double>();
+            var txWeightSum = new Dictionary<string, double>();
+
+            foreach (var node in allRxNodes)
+            {
+                int rxBaseIndex = rxIndexMap[node.Rx.Id];
+                int txBaseIndex = txIndexMap[node.Tx.Id];
+                double rxAdjRssi = final[rxBaseIndex];
+                double absorption = final[rxBaseIndex + 1];
+                double txRefRssi = final[txBaseIndex];
+
+                double calculatedDistance = Math.Pow(10, (txRefRssi - node.GetAdjustedRssi(rxAdjRssi)) / (10.0 * absorption));
+                double mapDistance = node.Rx.Location.DistanceTo(node.Tx.Location);
+                double weight = nodeWeights[node];
+                double err = weight * calculateDistanceError(calculatedDistance, mapDistance);
+
+                rxErrorSum[node.Rx.Id] = rxErrorSum.GetValueOrDefault(node.Rx.Id) + err;
+                rxWeightSum[node.Rx.Id] = rxWeightSum.GetValueOrDefault(node.Rx.Id) + weight;
+                txErrorSum[node.Tx.Id] = txErrorSum.GetValueOrDefault(node.Tx.Id) + err;
+                txWeightSum[node.Tx.Id] = txWeightSum.GetValueOrDefault(node.Tx.Id) + weight;
+            }
+
+            double? PerNodeError(Dictionary<string, double> errSum, Dictionary<string, double> wSum, string id)
+                => wSum.TryGetValue(id, out var w) && w > 0 ? Math.Sqrt(errSum[id] / w) : null;
 
             // Process Rx node results
             foreach (var rxId in uniqueRxIds)
             {
                 int baseIndex = rxIndexMap[rxId];
-                double rxAdjRssi = result.MinimizingPoint[baseIndex];
-                double absorption = result.MinimizingPoint[baseIndex + 1];
+                double rxAdjRssi = final[baseIndex];
+                double absorption = final[baseIndex + 1];
 
                 // Ensure values are within bounds (should be already)
                 rxAdjRssi = Math.Max(optimization.RxAdjRssiMin, Math.Min(rxAdjRssi, optimization.RxAdjRssiMax));
@@ -253,18 +285,18 @@ public class PerNodeAbsorptionRxTx : IOptimizer
                 var n = or.Nodes.GetOrAdd(rxId);
                 n.RxAdjRssi = rxAdjRssi;
                 n.Absorption = absorption;
-                n.Error = result.FunctionInfoAtMinimum.Value;
+                n.Error = PerNodeError(rxErrorSum, rxWeightSum, rxId);
             }
 
             // Process Tx node results
             foreach (var txId in uniqueTxIds)
             {
-                double txRefRssi = result.MinimizingPoint[txIndexMap[txId]];
+                double txRefRssi = final[txIndexMap[txId]];
                 txRefRssi = Math.Max(optimization.TxRefRssiMin, Math.Min(txRefRssi, optimization.TxRefRssiMax));
 
                 var n = or.Nodes.GetOrAdd(txId);
                 n.TxRefRssi = txRefRssi;
-                n.Error = result.FunctionInfoAtMinimum.Value;
+                n.Error = PerNodeError(txErrorSum, txWeightSum, txId);
             }
         }
         catch (Exception ex)

--- a/src/Optimizers/RxAdjRssiOptimizer.cs
+++ b/src/Optimizers/RxAdjRssiOptimizer.cs
@@ -22,6 +22,11 @@ public class RxAdjRssiOptimizer : IOptimizer
         OptimizationResults or = new();
         var optimization = _state.Config?.Optimization;
 
+        // This optimizer fits only RxAdjRssi. It holds path-loss exponent fixed at the
+        // midpoint of the configured bounds purely as a modeling constant for that fit;
+        // it does NOT estimate absorption. Emitting this constant as a proposed Absorption
+        // would clobber every node's real per-node absorption with the same value (the
+        // "all nodes pinned to ~midpoint" degeneracy), so it is deliberately not proposed.
         var absorption = ((optimization?.AbsorptionMax - optimization?.AbsorptionMin) / 2d) + optimization?.AbsorptionMin ?? 3d;
 
         foreach (var g in os.ByRx())
@@ -63,7 +68,7 @@ public class RxAdjRssiOptimizer : IOptimizer
                 var rxAdjRssi = result.MinimizingPoint[0];
                 if (rxAdjRssi < optimization?.RxAdjRssiMin) rxAdjRssi = optimization.RxAdjRssiMin;
                 if (rxAdjRssi > optimization?.RxAdjRssiMax) rxAdjRssi = optimization.RxAdjRssiMax;
-                or.Nodes.Add(g.Key.Id, new ProposedValues { RxAdjRssi = rxAdjRssi, Absorption = absorption, Error = result.FunctionInfoAtMinimum.Value });
+                or.Nodes.Add(g.Key.Id, new ProposedValues { RxAdjRssi = rxAdjRssi, Error = result.FunctionInfoAtMinimum.Value });
             }
             catch (Exception ex)
             {

--- a/tests/ESPresense.Companion.Tests/Optimizers/PerNodeAbsorptionRxTxTests.cs
+++ b/tests/ESPresense.Companion.Tests/Optimizers/PerNodeAbsorptionRxTxTests.cs
@@ -1,0 +1,117 @@
+using ESPresense.Models;
+using ESPresense.Optimizers;
+using ESPresense.Services;
+using MathNet.Spatial.Euclidean;
+using Moq;
+
+namespace ESPresense.Companion.Tests.Optimizers;
+
+/// <summary>
+/// Regression test for the per-node Error reporting fix. The optimizer used to store the single
+/// global objective value on every node, so every node's Error was identical regardless of how
+/// well that node actually fit. Each node's Error should now reflect its own residuals.
+/// </summary>
+public class PerNodeAbsorptionRxTxTests
+{
+    private State _state = null!;
+    private string _configDir = null!;
+    private ConfigLoader _configLoader = null!;
+    private NodeTelemetryStore _nodeTelemetryStore = null!;
+    private Mock<IMqttCoordinator> _mockMqttCoordinator = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockMqttCoordinator = new Mock<IMqttCoordinator>();
+        _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_configDir);
+        _configLoader = new ConfigLoader(_configDir);
+        _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore);
+        // Config loads asynchronously via the file watcher; set it explicitly so the optimizer
+        // has its bounds (defaults: absorption [2,5], rxAdj [-5,30], txRef [-70,-50]).
+        _state.Config = new Config();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _configLoader.StopAsync(CancellationToken.None);
+        _configLoader.Dispose();
+        if (Directory.Exists(_configDir))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                try { Directory.Delete(_configDir, recursive: true); break; }
+                catch (IOException) when (i < 4) { await Task.Delay(100); GC.Collect(); GC.WaitForPendingFinalizers(); }
+            }
+        }
+    }
+
+    [Test]
+    public void Optimize_ReportsDistinctPerNodeError()
+    {
+        // Two receivers hearing the same transmitters. rxGood's RSSI matches the log-distance
+        // model; rxBad's RSSI is inconsistent with geometry, so its residuals must be larger.
+        const double refRssi = -59;
+        const double absorption = 3.0;
+
+        // Separate transmitters per receiver so their fits don't couple through a shared txRef.
+        var goodTx = new[]
+        {
+            new OptNode { Id = "txA", Name = "txA", Location = new Point3D(0, 0, 0) },
+            new OptNode { Id = "txB", Name = "txB", Location = new Point3D(10, 0, 0) },
+            new OptNode { Id = "txC", Name = "txC", Location = new Point3D(0, 10, 0) }
+        };
+        var badTx = new[]
+        {
+            new OptNode { Id = "txD", Name = "txD", Location = new Point3D(20, 0, 0) },
+            new OptNode { Id = "txE", Name = "txE", Location = new Point3D(0, 20, 0) },
+            new OptNode { Id = "txF", Name = "txF", Location = new Point3D(20, 20, 0) }
+        };
+
+        var rxGood = new OptNode { Id = "rxGood", Name = "rxGood", Location = new Point3D(3, 4, 0) };
+        var rxBad = new OptNode { Id = "rxBad", Name = "rxBad", Location = new Point3D(16, 8, 0) };
+
+        var os = new OptimizationSnapshot();
+
+        foreach (var tx in goodTx)
+        {
+            double d = rxGood.Location.DistanceTo(tx.Location);
+            os.Measures.Add(new Measure
+            {
+                Rx = rxGood, Tx = tx, RssiRxAdj = 0, RefRssi = refRssi, Distance = d,
+                Rssi = refRssi - 10 * absorption * Math.Log10(d) // consistent with model
+            });
+        }
+
+        // Alternating-sign offsets: no single rxAdj/absorption/txRef can satisfy all three, so
+        // rxBad carries an irreducible residual that the well-fitting rxGood does not.
+        double[] offsets = { +12, -12, +12 };
+        for (int i = 0; i < badTx.Length; i++)
+        {
+            double d = rxBad.Location.DistanceTo(badTx[i].Location);
+            os.Measures.Add(new Measure
+            {
+                Rx = rxBad, Tx = badTx[i], RssiRxAdj = 0, RefRssi = refRssi, Distance = d,
+                Rssi = refRssi - 10 * absorption * Math.Log10(d) + offsets[i]
+            });
+        }
+
+        var optimizer = new PerNodeAbsorptionRxTx(_state);
+        var results = optimizer.Optimize(os, new Dictionary<string, NodeSettings>());
+
+        Assert.That(results.Nodes.ContainsKey("rxGood"), Is.True);
+        Assert.That(results.Nodes.ContainsKey("rxBad"), Is.True);
+
+        var errGood = results.Nodes["rxGood"].Error;
+        var errBad = results.Nodes["rxBad"].Error;
+
+        Assert.That(errGood, Is.Not.Null);
+        Assert.That(errBad, Is.Not.Null);
+        Assert.That(errGood, Is.Not.EqualTo(errBad),
+            "Per-node Error must be node-specific, not the shared global objective value.");
+        Assert.That(errBad!.Value, Is.GreaterThan(errGood!.Value),
+            "The receiver whose RSSI contradicts geometry should report the larger per-node error.");
+    }
+}

--- a/tests/ESPresense.Companion.Tests/Optimizers/RxAdjRssiOptimizerTests.cs
+++ b/tests/ESPresense.Companion.Tests/Optimizers/RxAdjRssiOptimizerTests.cs
@@ -1,0 +1,112 @@
+using ESPresense.Models;
+using ESPresense.Optimizers;
+using ESPresense.Services;
+using MathNet.Spatial.Euclidean;
+using Moq;
+
+namespace ESPresense.Companion.Tests.Optimizers;
+
+/// <summary>
+/// Regression tests for the "all nodes pinned to the same absorption" degeneracy.
+///
+/// RxAdjRssiOptimizer fits only RxAdjRssi; it holds the path-loss exponent fixed at the
+/// midpoint of the configured bounds as a modeling constant. It used to emit that constant
+/// as a proposed Absorption, and because it runs first in the legacy pipeline and the runner
+/// applies any non-null Absorption, every node's real per-node absorption got overwritten with
+/// the same value. These tests pin the contract that it never proposes Absorption.
+/// </summary>
+public class RxAdjRssiOptimizerTests
+{
+    private State _state = null!;
+    private string _configDir = null!;
+    private ConfigLoader _configLoader = null!;
+    private NodeTelemetryStore _nodeTelemetryStore = null!;
+    private Mock<IMqttCoordinator> _mockMqttCoordinator = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockMqttCoordinator = new Mock<IMqttCoordinator>();
+        _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_configDir);
+
+        _configLoader = new ConfigLoader(_configDir);
+        _nodeTelemetryStore = new NodeTelemetryStore(_mockMqttCoordinator.Object);
+        _state = new State(_configLoader, _nodeTelemetryStore);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _configLoader.StopAsync(CancellationToken.None);
+        _configLoader.Dispose();
+
+        if (Directory.Exists(_configDir))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                try
+                {
+                    Directory.Delete(_configDir, recursive: true);
+                    break;
+                }
+                catch (IOException) when (i < 4)
+                {
+                    await Task.Delay(100);
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void Optimize_DoesNotPropose_Absorption()
+    {
+        var snapshot = BuildSnapshotWithReceiver("rx1", txCount: 4);
+
+        var optimizer = new RxAdjRssiOptimizer(_state);
+        var results = optimizer.Optimize(snapshot, new Dictionary<string, NodeSettings>());
+
+        Assert.That(results.Nodes, Is.Not.Empty, "Optimizer should produce a result for a receiver hearing >=3 transmitters");
+        foreach (var (id, proposed) in results.Nodes)
+        {
+            Assert.That(proposed.Absorption, Is.Null,
+                $"RxAdjRssiOptimizer must not propose Absorption for {id}; doing so clobbers per-node absorption.");
+            Assert.That(proposed.RxAdjRssi, Is.Not.Null, $"RxAdjRssiOptimizer should propose RxAdjRssi for {id}.");
+        }
+    }
+
+    /// <summary>
+    /// Builds a snapshot with one receiver that hears <paramref name="txCount"/> transmitters at
+    /// increasing distances, with RSSI generated from a plausible log-distance model so the fit is
+    /// well-posed (the optimizer requires >=3 transmitters per receiver).
+    /// </summary>
+    private static OptimizationSnapshot BuildSnapshotWithReceiver(string rxId, int txCount)
+    {
+        const double refRssi = -59;
+        const double absorption = 3.0;
+
+        var rx = new OptNode { Id = rxId, Name = rxId, Location = new Point3D(0, 0, 0) };
+        var os = new OptimizationSnapshot();
+
+        for (int i = 0; i < txCount; i++)
+        {
+            double distance = 2.0 + i * 2.0;
+            var tx = new OptNode { Id = $"tx{i}", Name = $"tx{i}", Location = new Point3D(distance, 0, 0) };
+            double rssi = refRssi - 10 * absorption * Math.Log10(distance);
+
+            os.Measures.Add(new Measure
+            {
+                Rx = rx,
+                Tx = tx,
+                Rssi = rssi,
+                RssiRxAdj = 0,
+                RefRssi = refRssi,
+                Distance = distance
+            });
+        }
+
+        return os;
+    }
+}


### PR DESCRIPTION
Fixes the "every node converges to the same absorption" degeneracy from two independent angles, found while investigating real captures + a live 10-node deployment.

## 1. Legacy pipeline: RxAdjRssiOptimizer clobbered per-node absorption
`RxAdjRssiOptimizer` fits **only** `RxAdjRssi`, holding the path-loss exponent fixed at the **midpoint of the absorption bounds** as a modeling constant — but it emitted that constant as a *proposed* `Absorption` for every node. It runs **first** in the legacy pipeline and the runner applies any non-null `Absorption` (`OptimizationRunner.cs:162`), so it overwrote each node's real per-node absorption with the same value every cycle. The downstream optimizers that actually estimate per-node absorption (incl. the proper variance-weighted `IsotonicRegressionOptimizer`) were then masked by the all-or-nothing global acceptance.

**Fix:** `RxAdjRssiOptimizer` no longer proposes `Absorption` (only `RxAdjRssi` + `Error`).

## 2. Active modes (global/per-node): silent bound railing
Most deployments run `global_absorption` or `per_node_absorption`, not legacy. There the same symptom is **bound railing**: with a narrow absorption window the optimizer clamps nodes onto a limit and reports a uniform, confidently-wrong calibration with no signal that anything is wrong.

- **Rail-to-bound warning** (`OptimizationRunner`): warn when an applied `Absorption`/`RxAdj`/`TxRef` value lands on a configured min/max bound — a clamped value is not a true fit.
- **Wider default** (`Config`): `absorption_max` default 4 → 5. Indoor effective path-loss exponents commonly run 3.5–4.5 with body shadowing/appliances; the old default clamped most real nodes at the ceiling.
- **Real per-node Error** (`PerNodeAbsorptionRxTx`, `GlobalAbsorptionRxTxOptimizer`): report the weighted RMS of each node's own residuals instead of storing the single global objective value on every node (which made all Errors identical).

## Live validation (10-node house, per_node_absorption)
- `[2.8, 3.2]` window → **8/10 nodes railed to 3.20**.
- Widened to `[2.0, 5.0]` → genuine per-node spread **2.02–5.00**; global fit error 18.5 → 13.0.
- Rail warning fired on `kitchen` (wants absorption > 5.0).
- Per-node Error now spans ~1 (good fit) to ~9 (poor fit) instead of an identical 18.5.

## Tests
- `RxAdjRssiOptimizerTests` — RxAdj optimizer never proposes Absorption.
- `PerNodeAbsorptionRxTxTests` — per-node Error is node-specific.
- Full suite: 162 passed, 2 skipped.

## Follow-up (not in this PR)
The runner's acceptance metric is a **global** pooled Pearson/RMSE, largely insensitive to per-node quality and can reject good per-node fits wholesale. Making acceptance per-node is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-node error metrics now computed during calibration optimization for improved diagnostics and visibility into node-specific calibration quality.
  * Warnings logged when proposed calibration values are constrained to configured bounds.

* **Improvements**
  * Enhanced handling of absorption parameters in optimization algorithms for improved stability.

* **Chores**
  * Updated gitignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->