### PR TITLE
fix(mqtt): retain device_tracker state topic, clear on delete

### DIFF
--- a/src/Services/DeviceService.cs
+++ b/src/Services/DeviceService.cs
@@ -139,6 +139,18 @@ public class DeviceService
             _logger.LogWarning(ex, "Failed to delete HA auto-discovery entries for device {DeviceId}", device.Id);
         }
 
+        try
+        {
+            // Clear retained state/attributes topics so a deleted device doesn't leave a stale
+            // retained message behind on the broker for any client that (re)subscribes later.
+            await _mqtt.EnqueueAsync($"espresense/companion/{device.Id}", null, retain: true);
+            await _mqtt.EnqueueAsync($"espresense/companion/{device.Id}/attributes", null, retain: true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to clear retained MQTT state for device {DeviceId}", device.Id);
+        }
+
         // Notify connected clients to remove device immediately
         _events.OnDeviceRemoved(device.Id);
 

--- a/src/Services/DeviceService.cs
+++ b/src/Services/DeviceService.cs
@@ -139,18 +139,21 @@ public class DeviceService
             _logger.LogWarning(ex, "Failed to delete HA auto-discovery entries for device {DeviceId}", device.Id);
         }
 
-        try
+        foreach (var topic in new[]
         {
-            // Clear retained state/attributes topics so a deleted device doesn't leave a stale
-            // retained message behind on the broker for any client that (re)subscribes later.
-            await _mqtt.EnqueueAsync($"espresense/companion/{device.Id}", null, retain: true);
-            await _mqtt.EnqueueAsync($"espresense/companion/{device.Id}/attributes", null, retain: true);
-        }
-        catch (Exception ex)
+            $"espresense/companion/{device.Id}",
+            $"espresense/companion/{device.Id}/attributes"
+        })
         {
-            _logger.LogWarning(ex, "Failed to clear retained MQTT state for device {DeviceId}", device.Id);
+            try
+            {
+                await _mqtt.EnqueueAsync(topic, null, retain: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clear retained MQTT topic {Topic}", topic);
+            }
         }
-
         // Notify connected clients to remove device immediately
         _events.OnDeviceRemoved(device.Id);
 

--- a/src/Services/MultiScenarioLocator.cs
+++ b/src/Services/MultiScenarioLocator.cs
@@ -44,7 +44,7 @@ public class MultiScenarioLocator(DeviceTracker dl,
             var stateChanged = device.ReportedState != "not_home";
             if (stateChanged)
             {
-                if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home"))
+                if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home", retain: true))
                     device.ReportedState = "not_home";
             }
 
@@ -161,7 +161,7 @@ public class MultiScenarioLocator(DeviceTracker dl,
             var newState = device.Room?.Name ?? device.Floor?.Name ?? "not_home";
             if (newState != device.ReportedState)
             {
-                if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", newState))
+                if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", newState, retain: true))
                 {
                     moved += 1;
                     device.ReportedState = newState;
@@ -170,7 +170,7 @@ public class MultiScenarioLocator(DeviceTracker dl,
         }
         else if (device.ReportedState != "not_home")
         {
-            if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home"))
+            if (await mqtt.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home", retain: true))
             {
                 moved += 1;
                 device.ReportedState = "not_home";

--- a/tests/ESPresense.Companion.Tests/DeviceServiceTests.cs
+++ b/tests/ESPresense.Companion.Tests/DeviceServiceTests.cs
@@ -1,0 +1,44 @@
+using ESPresense.Controllers;
+using ESPresense.Models;
+using ESPresense.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace ESPresense.Companion.Tests;
+
+public class DeviceServiceTests
+{
+    private static (DeviceService service, State state, Mock<IMqttCoordinator> mqttMock) CreateService()
+    {
+        var mockConfigLoader = new Mock<ConfigLoader>("test-config-dir");
+        var mqttMock = new Mock<IMqttCoordinator>();
+        var nodeTelemetryStore = new NodeTelemetryStore(mqttMock.Object);
+        var state = new State(mockConfigLoader.Object, nodeTelemetryStore);
+        var events = new GlobalEventDispatcher();
+        var logger = new Mock<ILogger<DeviceService>>();
+
+        var service = new DeviceService(state, mqttMock.Object, events, logger.Object);
+        return (service, state, mqttMock);
+    }
+
+    [Test]
+    public async Task DeleteAsync_ClearsRetainedStateAndAttributesTopics()
+    {
+        var (service, state, mqttMock) = CreateService();
+        var device = new Device("kitchen:phone", null, TimeSpan.FromSeconds(30)) { ReportedState = "kitchen" };
+        state.Devices[device.Id] = device;
+
+        mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}", null, true))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+        mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}/attributes", null, true))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var deleted = await service.DeleteAsync(device.Id);
+
+        Assert.That(deleted, Is.True);
+        Assert.That(state.Devices.ContainsKey(device.Id), Is.False);
+        mqttMock.Verify();
+    }
+}

--- a/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
+++ b/tests/ESPresense.Companion.Tests/MultiScenarioLocatorTests.cs
@@ -52,7 +52,7 @@ public class MultiScenarioLocatorTests
         };
         device.Scenarios.Add(scenario);
 
-        mqttMock.Setup(m => m.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home", false))
+        mqttMock.Setup(m => m.TryEnqueueAsync($"espresense/companion/{device.Id}", "not_home", true))
                 .ReturnsAsync(true)
                 .Verifiable();
 
@@ -92,7 +92,7 @@ public class MultiScenarioLocatorTests
         device.SetAnchor(new DeviceAnchor(anchorLocation, null, null));
         state.Devices[device.Id] = device;
 
-        mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}", "not_home", false))
+        mqttMock.Setup(m => m.EnqueueAsync($"espresense/companion/{device.Id}", "not_home", true))
             .Returns(Task.CompletedTask)
             .Verifiable();
 


### PR DESCRIPTION
## Summary
- Retains `espresense/companion/{id}` (the HA `device_tracker` state topic), matching the `/attributes` topic which has always been retained. Without this, any HA MQTT resubscribe (broker restart, integration reload, network blip) with no intervening room change leaves the entity stuck at `unknown` indefinitely — Companion's own `/api/state/devices` is correct the whole time, only the retained-message gap causes the drift.
- Addresses @DTTerastar's concern in the issue thread ("if we retain, we need to have code to delete it") by extending `DeviceService.PerformDeviceCleanup` to publish retained-null to both the state and attributes topics when a device is deleted (manual delete, bulk delete, and the 30-day auto-cleanup path all funnel through this one method). This also closes a pre-existing gap: the `/attributes` topic has been retained since it was added, but nothing has ever cleared it on device delete — that leak just wasn't visible because non-retained state never "stuck" until now.
- Self-healing case (device leaves BLE range / no anchor / room goes null) already publishes `not_home` on the transition — retain:true doesn't change that path, it just means the *replacement* message is retained too.

## Why this scope
Went a line further than the one-line suggestion in the issue because retain-without-cleanup is exactly the failure mode being asked about: an orphaned retained message on the broker for any device that's later deleted. The cleanup uses the same null-payload/retain:true pattern already established elsewhere in this codebase (`AutoDiscovery.Delete`, `NodeTelemetryStore`, `LeaseService`), so it's consistent with existing conventions rather than new machinery.

Closes #1625

## Test plan
- [x] `dotnet build` — backend + tests compile
- [x] Updated `MultiScenarioLocatorTests` mocks to expect `retain: true` on the state topic (both the anchored and normal-locate code paths)
- [x] Added `DeviceServiceTests.DeleteAsync_ClearsRetainedStateAndAttributesTopics` covering the new cleanup behavior
- [x] Full backend suite: 161 passed, 2 skipped (pre-existing), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a device is deleted, the system now clears any stale retained MQTT state for both the device’s main topic and its attributes topic.
  * Companion state updates during scenario transitions are now published with MQTT retain enabled to preserve the latest location/presence state.

* **Tests**
  * Added new unit coverage verifying retained MQTT state and attributes are cleared during device deletion.
  * Updated MultiScenarioLocator tests to expect retained MQTT publishes for the affected transition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->