### PR TITLE
Warn when a node's z is outside its floors' bounds

### DIFF
--- a/src/Models/Node.cs
+++ b/src/Models/Node.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json.Serialization;
 using ESPresense.Converters;
 using MathNet.Spatial.Euclidean;
+using Serilog;
 using SQLite;
 using ESPresense.Extensions;
 
@@ -57,9 +58,18 @@ public class Node(string id, NodeSourceType sourceType)
         Floors = floors.ToArray();
         double[]? point = cn.Point?.EnsureLength(3);
         Location = new Point3D(point?[0] ?? 0, point?[1] ?? 0, point?[2] ?? 0);
+        ZOutOfBounds = point != null && Floors.Any(f => f.Bounds is { Length: >= 2 }) && !Floors.Any(f => f.Contained(Location.Z));
+        if (ZOutOfBounds)
+            Log.Warning("Node {Node} z={Z} is outside the z-range of its floor(s) {Floors}. Coordinates are absolute: z must include the floor's base elevation (a node 1.7m up on a floor whose bounds start at z=3 has z=4.7). This node will be excluded from locating on those floors.",
+                Name ?? Id, Location.Z,
+                string.Join(", ", Floors.Where(f => f.Bounds is { Length: >= 2 }).Select(f => $"{f.Id} [{f.Bounds![0].Z}..{f.Bounds[1].Z}]")));
         Stationary = cn.Stationary;
         SourceType = NodeSourceType.Config;
     }
+
+    /// <summary>True when a configured point's z falls outside the z-range of every floor this node is assigned to (a common sign of floor-relative instead of absolute coordinates).</summary>
+    [Ignore]
+    public bool ZOutOfBounds { get; private set; }
 
     public Floor[]? Floors { get; private set; }
 

--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -243,6 +243,9 @@ floors:
           - [1.3,17.1]
 
 # Locations of espresense nodes in meters
+# Coordinates are absolute (same origin as rooms/floors), NOT relative to the room or floor:
+# z must include the floor's base elevation, e.g. a node mounted 1.7m up a wall on a floor
+# whose bounds start at z=3 has point z of 4.7
 nodes:
   - name: Master
     point: [3.4, 10.4, 3.4]

--- a/tests/ESPresense.Companion.Tests/Models/NodeTests.cs
+++ b/tests/ESPresense.Companion.Tests/Models/NodeTests.cs
@@ -1,0 +1,51 @@
+using ESPresense.Models;
+
+namespace ESPresense.Companion.Tests.Models;
+
+[TestFixture]
+public class NodeTests
+{
+    private static Floor MakeFloor(double zMin, double zMax, bool withBounds = true)
+    {
+        var floor = new Floor();
+        var cf = new ConfigFloor { Id = "second", Name = "Second Floor" };
+        if (withBounds) cf.Bounds = new[] { new double[] { 0, 0, zMin }, new double[] { 12, 12, zMax } };
+        floor.Update(new Config(), cf);
+        return floor;
+    }
+
+    private static Node MakeNode(double[]? point, Floor floor)
+    {
+        var node = new Node("test", NodeSourceType.Config);
+        node.Update(new Config(), new ConfigNode { Name = "test", Point = point }, new[] { floor });
+        return node;
+    }
+
+    [Test]
+    public void ZOutOfBounds_TrueWhenFloorRelativeZUsedOnUpperFloor()
+    {
+        var node = MakeNode(new double[] { 1, 2, 0.5 }, MakeFloor(3, 6));
+        Assert.That(node.ZOutOfBounds, Is.True);
+    }
+
+    [Test]
+    public void ZOutOfBounds_FalseWhenZWithinFloorBounds()
+    {
+        var node = MakeNode(new double[] { 1, 2, 4.7 }, MakeFloor(3, 6));
+        Assert.That(node.ZOutOfBounds, Is.False);
+    }
+
+    [Test]
+    public void ZOutOfBounds_FalseWhenNoPointConfigured()
+    {
+        var node = MakeNode(null, MakeFloor(3, 6));
+        Assert.That(node.ZOutOfBounds, Is.False);
+    }
+
+    [Test]
+    public void ZOutOfBounds_FalseWhenFloorHasNoBounds()
+    {
+        var node = MakeNode(new double[] { 1, 2, 0.5 }, MakeFloor(0, 0, withBounds: false));
+        Assert.That(node.ZOutOfBounds, Is.False);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up to #955. Node `point` coordinates are absolute (same origin as rooms/floors), but the docs said "x,y,z coordinates within room", so users on multi-story homes entered floor-relative z values. Those nodes:
- silently fail the floor bounds filter in `BaseMultilateralizer` and are excluded from locating on their own floor
- render at ground level in the 3D view (rooms are lifted to `floor.bounds[0][2]`, nodes are not)

This adds a `Log.Warning` at config load when a configured node's z falls outside the z-range of every floor it's assigned to, exposes it as `Node.ZOutOfBounds`, and clarifies the example config. A docs PR fixing the "within room" wording is going to ESPresense.com separately.

## Test plan
- [x] `dotnet test` — 164 passed, including 4 new `NodeTests` covering out-of-range, in-range, no-point, and unbounded-floor cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbJPc22rkttkVsifQgUSbY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and warning logs when a node’s vertical position falls outside all assigned floor bounds.

* **Documentation**
  * Clarified that node coordinates use an absolute reference, and that vertical coordinates must include the floor’s base elevation.

* **Tests**
  * Added coverage for nodes above, within, or outside configured floor bounds, including cases with missing coordinates or bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->