### PR TITLE
Match device id/name globs case-insensitively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y ca-certificates curl gnupg && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
     apt-get install -y nodejs && \
-    npm install -g pnpm && \
+    npm install -g pnpm@10 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/Models/State.cs
+++ b/src/Models/State.cs
@@ -22,6 +22,9 @@ public class State
     /// Loading the configuration populates Floors, Nodes, device tracking structures (by literal and pattern globs),
     /// selects the locators' weighting strategy, and marks existing Devices for checking.
     /// </remarks>
+    // ponytail: device ids/names are matched case-insensitively everywhere else (all the dictionaries are OrdinalIgnoreCase), globs must agree
+    private static readonly GlobOptions GlobOpts = new() { Evaluation = { CaseInsensitive = true } };
+
     public State(ConfigLoader cl, NodeTelemetryStore nts)
     {
         _nts = nts;
@@ -36,7 +39,7 @@ public class State
             foreach (var d in c.Devices ?? Enumerable.Empty<ConfigDevice>())
                 if (!string.IsNullOrWhiteSpace(d.Id))
                 {
-                    var glob = Glob.Parse(d.Id);
+                    var glob = Glob.Parse(d.Id, GlobOpts);
                     if (glob.Tokens.All(a => a is LiteralToken))
                         configDeviceById.GetOrAdd(d.Id, a => d);
                     else
@@ -48,7 +51,7 @@ public class State
             foreach (var d in c.Devices ?? Enumerable.Empty<ConfigDevice>())
                 if (!string.IsNullOrWhiteSpace(d.Name))
                 {
-                    var glob = Glob.Parse(d.Name);
+                    var glob = Glob.Parse(d.Name, GlobOpts);
                     if (glob.Tokens.All(a => a is LiteralToken))
                         configDeviceByName.GetOrAdd(d.Name, a => d);
                     else
@@ -269,8 +272,8 @@ public class State
     private bool IsExcluded(Device device)
     {
         return Config?.ExcludeDevices.Any(d =>
-            (!string.IsNullOrWhiteSpace(d.Id) && !string.IsNullOrWhiteSpace(device.Id) && Glob.Parse(d.Id).IsMatch(device.Id)) ||
-            (!string.IsNullOrWhiteSpace(d.Name) && !string.IsNullOrWhiteSpace(device.Name) && Glob.Parse(d.Name).IsMatch(device.Name))
+            (!string.IsNullOrWhiteSpace(d.Id) && !string.IsNullOrWhiteSpace(device.Id) && Glob.Parse(d.Id, GlobOpts).IsMatch(device.Id)) ||
+            (!string.IsNullOrWhiteSpace(d.Name) && !string.IsNullOrWhiteSpace(device.Name) && Glob.Parse(d.Name, GlobOpts).IsMatch(device.Name))
         ) ?? false;
     }
 }

--- a/tests/ESPresense.Companion.Tests/Models/StateGlobCaseTests.cs
+++ b/tests/ESPresense.Companion.Tests/Models/StateGlobCaseTests.cs
@@ -18,8 +18,10 @@ public class StateGlobCaseTests
         await File.WriteAllTextAsync(Path.Combine(_configDir, "config.yaml"), """
             devices:
               - id: "iBeacon:*"
+              - name: "Phone *"
             exclude_devices:
               - id: "iBeacon:BBBB*"
+              - name: "Phone GUEST*"
             """);
 
         _configLoader = new ConfigLoader(_configDir);
@@ -42,9 +44,20 @@ public class StateGlobCaseTests
     [TestCase("iBeacon:bbbb-1", false)]  // exclude glob must match regardless of case
     [TestCase("IBEACON:BBBB-1", false)]
     [TestCase("other:1", false)]
-    public void ShouldTrack_GlobsAreCaseInsensitive(string id, bool expected)
+    public void ShouldTrack_IdGlobsAreCaseInsensitive(string id, bool expected)
     {
         var device = new Device(id, null, TimeSpan.FromSeconds(30));
+        Assert.That(_state.ShouldTrack(device), Is.EqualTo(expected));
+    }
+
+    [TestCase("Phone Bob", true)]
+    [TestCase("phone bob", true)]        // include glob must match regardless of case
+    [TestCase("Phone guest 1", false)]   // exclude glob must match regardless of case
+    [TestCase("PHONE GUEST 1", false)]
+    [TestCase("Tablet Bob", false)]
+    public void ShouldTrack_NameGlobsAreCaseInsensitive(string name, bool expected)
+    {
+        var device = new Device("xyz:1", null, TimeSpan.FromSeconds(30)) { Name = name };
         Assert.That(_state.ShouldTrack(device), Is.EqualTo(expected));
     }
 }

--- a/tests/ESPresense.Companion.Tests/Models/StateGlobCaseTests.cs
+++ b/tests/ESPresense.Companion.Tests/Models/StateGlobCaseTests.cs
@@ -1,0 +1,50 @@
+using ESPresense.Models;
+using ESPresense.Services;
+using Moq;
+
+namespace ESPresense.Companion.Tests.Models;
+
+public class StateGlobCaseTests
+{
+    private string _configDir = null!;
+    private ConfigLoader _configLoader = null!;
+    private State _state = null!;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _configDir = Path.Combine(TestContext.CurrentContext.WorkDirectory, "cfg", Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_configDir);
+        await File.WriteAllTextAsync(Path.Combine(_configDir, "config.yaml"), """
+            devices:
+              - id: "iBeacon:*"
+            exclude_devices:
+              - id: "iBeacon:BBBB*"
+            """);
+
+        _configLoader = new ConfigLoader(_configDir);
+        _state = new State(_configLoader, new NodeTelemetryStore(new Mock<IMqttCoordinator>().Object));
+
+        for (var i = 0; i < 50 && _state.Config == null; i++) await Task.Delay(20);
+        Assert.That(_state.Config, Is.Not.Null, "config never loaded");
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await _configLoader.StopAsync(CancellationToken.None);
+        _configLoader.Dispose();
+        if (Directory.Exists(_configDir)) Directory.Delete(_configDir, recursive: true);
+    }
+
+    [TestCase("iBeacon:AAAA-1", true)]
+    [TestCase("ibeacon:aaaa-1", true)]   // include glob must match regardless of case
+    [TestCase("iBeacon:bbbb-1", false)]  // exclude glob must match regardless of case
+    [TestCase("IBEACON:BBBB-1", false)]
+    [TestCase("other:1", false)]
+    public void ShouldTrack_GlobsAreCaseInsensitive(string id, bool expected)
+    {
+        var device = new Device(id, null, TimeSpan.FromSeconds(30));
+        Assert.That(_state.ShouldTrack(device), Is.EqualTo(expected));
+    }
+}


### PR DESCRIPTION
## Problem

Device and node lookups all use `OrdinalIgnoreCase` dictionaries, but the config globs for `devices:` and `exclude_devices:` were parsed with DotNet.Globbing's default **case-sensitive** evaluation.

So an exclude entry like:

```yaml
exclude_devices:
  - id: "iBeacon:E5CA1ADE-F007-BA11-*"
```

silently never matched a device reporting `ibeacon:e5ca1ade-...`. Same for tracked ids/names in `devices:`.

## Fix

`src/Models/State.cs` — one shared `GlobOptions { Evaluation = { CaseInsensitive = true } }` passed to all four `Glob.Parse` calls (tracked ids, tracked names, and both `IsExcluded` paths).

## Also: unblocks the Docker add-on build

`Dockerfile` installed pnpm unpinned (`npm install -g pnpm`), so builds started picking up **pnpm 11**, where ignored build scripts are a hard `ERR_PNPM_IGNORED_BUILDS` failure rather than a warning — `esbuild@0.27.7` trips it and `pnpm install` exits 1 during publish. CI already pins pnpm 10 via `pnpm/action-setup`, which is why `build` stayed green while `Deploy to Docker` went red. Pinned the Dockerfile to `pnpm@10` to match. Pre-existing on main, not caused by the glob change.

## Test

`tests/ESPresense.Companion.Tests/Models/StateGlobCaseTests.cs` — 10 `ShouldTrack` cases over mixed-case ids and names against `devices: iBeacon:* / Phone *` and `exclude_devices: iBeacon:BBBB* / Phone GUEST*`. All pass with the fix; 4 fail (2 id, 2 name) with the option flipped back off.

Backend-only config matching change plus a build pin; no firmware impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qNaNQc6WPzJshprhyGo9G

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device IDs and names in tracking and exclusion rules are now matched without regard to letter casing.
  * Include and exclude patterns consistently recognize differently cased device identifiers and names.

* **Tests**
  * Added coverage verifying case-insensitive matching for device tracking and exclusion patterns.

* **Chores**
  * Standardized the package manager version used during application builds for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->