### PR TITLE
Dispatch release events to hassio-addons, not hass-addons

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -25,7 +25,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.ESPRESENSE_CONTENTS_TOKEN }}
-          repository: ESPresense/hass-addons
+          repository: ESPresense/hassio-addons
           event-type: update-version
           client-payload: >
             {


### PR DESCRIPTION
## Problem

`.github/workflows/release-dispatch.yml` dispatches `update-version` at `ESPresense/hass-addons`. That repo does not exist — the add-on repo is **`ESPresense/hassio-addons`**. Every published release has failed that step with:

```
Repository not found, OR token has insufficient permissions.
```

Caught on the v2.2.0 publish. The `ESPresense.com` step in the same job uses the same `ESPRESENSE_CONTENTS_TOKEN` and succeeded, so the token is fine — it was purely the repo name.

Impact: the HA add-on `config.yaml` version was never bumped by a release. It only recovered via the twice-weekly cron in `hassio-addons/.github/workflows/update-espresense-companion-stable.yaml`, so add-on users saw new versions on a Mon/Thu schedule rather than at release time.

## Fix

One word: `hass-addons` → `hassio-addons`.

The receiving workflow listens on `repository_dispatch: types: [update-version]` and ignores the payload (it queries the releases API for the latest non-draft, non-prerelease tag), so no payload change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qNaNQc6WPzJshprhyGo9G