### PR TITLE
Document exponential weighting lambda default as 1.5

### DIFF
--- a/src/config.example.yaml
+++ b/src/config.example.yaml
@@ -67,8 +67,8 @@ locators:
       props:
         # gaussian: sigma controls spread (higher = flatter weights, default: 0.3)
         sigma: 0.30
-        # exponential: lambda controls decay (higher = steeper decay, default: 3.0 for cubic)
-        # lambda: 3.0
+        # exponential: lambda controls decay (higher = steeper decay, default: 1.5)
+        # lambda: 1.5
 
   bfgs:
     enabled: false


### PR DESCRIPTION
## Problem

`src/Weighting/ExponentialWeighting.cs:14` defaults `lambda` to **1.5** (changed from 3.0 in #1461), but `src/config.example.yaml:70-71` still documents 3.0:

```yaml
# exponential: lambda controls decay (higher = steeper decay, default: 3.0 for cubic)
# lambda: 3.0
```

Anyone uncommenting that line got a decay rate twice as steep as the code default, and anyone reading the comment got the wrong idea of what `algorithm: exponential` does out of the box.

Called out while writing the v2.2.0 release notes.

## Fix

Comment now matches the code: default 1.5.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qNaNQc6WPzJshprhyGo9G