### PR TITLE
Wait for the release image before dispatching release events

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -8,6 +8,23 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for the release image to be published
+        # Docker Release builds on the tag push, which races this workflow's
+        # release:published trigger. hassio-addons smoke-tests by pulling the
+        # image, so don't notify anyone until the tag actually exists.
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          for i in $(seq 1 60); do
+            if curl -sf "https://hub.docker.com/v2/repositories/espresense/espresense-companion/tags/$TAG" >/dev/null; then
+              echo "espresense/espresense-companion:$TAG is published"
+              exit 0
+            fi
+            echo "waiting for espresense/espresense-companion:$TAG ($i/60)"
+            sleep 15
+          done
+          echo "timed out waiting for espresense/espresense-companion:$TAG" >&2
+          exit 1
+
       - name: Repository Dispatch to ESPresense.com
         uses: peter-evans/repository-dispatch@v4
         with:


### PR DESCRIPTION
## Problem

Found by watching the v2.2.1 release go out.

Two workflows fire off the same publish:

- **Docker Release** (`docker-rel.yml`) — triggers on the `v*` **tag push**, builds amd64 + arm64 + arm, takes ~3 minutes
- **Dispatch Events** (`release-dispatch.yml`) — triggers on **`release: published`**, which happens at essentially the same instant

The dispatch always wins that race. `hassio-addons` smoke-tests the release by pulling `espresense/espresense-companion:<version>` before it bumps the add-on, so on v2.2.1 it failed 27 seconds after publish:

```
Error response from daemon: manifest for espresense/espresense-companion:2.2.1 not found: manifest unknown
```

The add-on was left on 2.2.0 until the twice-weekly cron would have caught up. This was masked until now because #1660 — the dispatch never reached `hassio-addons` at all.

## Fix

Poll Docker Hub for the tag before notifying either downstream repo. 15s × 60 = 15 minute ceiling, then fail loudly rather than dispatching into a missing image.

Kept the `release: published` trigger so `github.ref` / `github.sha` in both dispatch payloads keep their current meaning — nothing downstream has to change.

## Alternative considered

Re-triggering on `workflow_run` of Docker Release would also order it correctly, but it changes what `github.ref` means in the payload (it becomes the triggering run's branch), which would need the ESPresense.com handler checked too. The poll is contained in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qNaNQc6WPzJshprhyGo9G