### PR TITLE
Use availability_topic in HA discovery (LWT was ignored)

### DIFF
--- a/src/Models/AutoDiscovery.cs
+++ b/src/Models/AutoDiscovery.cs
@@ -117,7 +117,7 @@ public class AutoDiscovery
 
         [JsonProperty("json_attributes_topic")] public string? JsonAttributesTopic { get; set; }
 
-        [JsonProperty("status_topic")] public string? EntityStatusTopic { get; set; }
+        [JsonProperty("availability_topic")] public string? EntityStatusTopic { get; set; }
 
         [JsonProperty("device")] public DeviceRecord? Device { get; set; }
 


### PR DESCRIPTION
## Summary
- `AutoDiscovery.DiscoveryRecord` emitted `"status_topic"`, which isn't an HA MQTT discovery key, so the LWT `offline` payload on `espresense/companion/status` was silently ignored and entities never went `unavailable`.
- Renamed to `availability_topic`. Payloads already match HA defaults (`online`/`offline`).
- Follow-up to #1634: with the state topic now retained, availability is what masks a stale retained room while companion is down.

## Test plan
- [x] `dotnet test` — 175 passed, 2 skipped
- [ ] Stop companion → `device_tracker.*` entities show `unavailable` in HA; start → recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iBewvi4YE9tAjybe2ESr3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated discovery messages to use the standard `availability_topic` JSON key for entity availability information.
  * Improved compatibility when reading and writing discovery messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->