### PR TITLE
fix(ui): don't use crypto.randomUUID for tooltip ids (#1664)

### DIFF
--- a/src/ui/src/lib/tooltip.ts
+++ b/src/ui/src/lib/tooltip.ts
@@ -1,12 +1,16 @@
 import type { Action } from 'svelte/action';
 import { computePosition, offset, flip, shift, autoUpdate } from '@floating-ui/dom';
 
+// ponytail: plain counter, not crypto.randomUUID() — ids only need to be unique
+// within the document, and randomUUID() is absent in insecure contexts (#1664).
+let tooltipSeq = 0;
+
 // A lightweight tooltip action that opens on hover/focus
 export const tooltip: Action<HTMLElement, string> = (node, content) => {
 	let tooltipEl: HTMLDivElement | null = null;
 	let cleanupAutoUpdate: (() => void) | null = null;
 	// Generate a unique, stable ID for this tooltip instance
-	const tooltipId = `tooltip-${crypto.randomUUID()}`;
+	const tooltipId = `tooltip-${++tooltipSeq}`;
 
 	/**
 	 * Ensure the tooltip DOM element exists, creating and initializing it if needed.

--- a/src/ui/tests/tooltip.spec.ts
+++ b/src/ui/tests/tooltip.spec.ts
@@ -281,4 +281,38 @@ test.describe('Tooltip', () => {
 		expect(tooltipText).toContain('Measured 3.0');
 		expect(tooltipText).toContain('Error 2.0');
 	});
+
+	test('renders calibration + tooltips without crypto.randomUUID (#1664)', async ({ page }) => {
+		const calibrationData = {
+			matrix: { 'Node A': { 'Node B': { distance: 5.0, rssi: -70, mapDistance: 4.5, diff: 0.5, percent: 0.111 } } },
+			rmse: 0.123,
+			r: 0.95
+		};
+
+		// Older HA WebViews / insecure contexts have no crypto.randomUUID
+		await page.addInitScript(() => {
+			// randomUUID lives on Crypto.prototype and is secure-context-gated
+			delete (Crypto.prototype as unknown as Record<string, unknown>).randomUUID;
+		});
+
+		await mockApi(page, { stubWebSocket: true });
+
+		await page.route('**/api/state/calibration', (route) => {
+			route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(calibrationData) });
+		});
+
+		await page.route('**/api/state/calibration/autoOptimize', (route) => {
+			route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ autoOptimize: false }) });
+		});
+
+		const errors: string[] = [];
+		page.on('pageerror', (e) => errors.push(e.message));
+
+		await page.goto('/calibration');
+		await page.waitForSelector('table');
+
+		await page.locator('table tbody td').filter({ hasText: '11%' }).hover();
+		await expect(page.locator('[role="tooltip"]')).toBeVisible();
+		expect(errors).toEqual([]);
+	});
 });


### PR DESCRIPTION
Fixes #1664 — `Uncaught TypeError: crypto.randomUUID is not a function` at `tooltip.ts:9`, which killed the entire companion UI on the calibration page.

## Cause

`crypto.randomUUID` is secure-context-gated, so it's `undefined` in the insecure / older-WebView contexts some Home Assistant installs run under. The `tooltip` action called it at attach time, so mounting `NodeCalibrationMatrix` threw before the page finished loading. The matrix is just the first caller — anything using `use:tooltip` would have done it.

## Fix

Tooltip ids only need to be unique within the document, so use a module counter and drop the `crypto` dependency entirely. Same ARIA behavior (`role="tooltip"` + `aria-describedby`), no fallback branch to maintain.

## Regression guard

One Playwright test that deletes `Crypto.prototype.randomUUID` via `addInitScript` (it lives on the prototype, not the instance — deleting the own property is a no-op), then loads `/calibration`, hovers a matrix cell, and asserts the tooltip renders with zero `pageerror`s.

Verified both directions: fails on the old code (tooltip never appears), passes on the new. All 6 tests in `tooltip.spec.ts` green.

## Scope

UI-only, two files, no firmware surface — no hardware test gate needed. Intended as a 2.2.2 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tbii3jPSYmhWU53jygomgm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tooltip rendering in older or insecure browser contexts where `crypto.randomUUID` is unavailable.
  - Calibration tooltips now display correctly without causing page errors.

- **Tests**
  - Added coverage verifying calibration pages and tooltips render successfully in environments without `crypto.randomUUID`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->